### PR TITLE
Updated wording in dataset_types.md

### DIFF
--- a/docs/dataset_types.md
+++ b/docs/dataset_types.md
@@ -54,7 +54,7 @@ The same as Type 1, but during training all instruments will be from the same po
 
 ### Dataset for validation
 
-* Validation dataset must be the same as Type 1 for training, but also each folder must include `mixture.wav` for each song. `mixture.wav` - it's sum of all stems for song.
+* The validation dataset must be the same structure as type 1 datasets (regardless of what type of dataset you're using for training), but also each folder must include `mixture.wav` for each song. `mixture.wav` - is the sum of all stems for song.
 
 Example:
 ```


### PR DESCRIPTION
Small change to the wording to highlight that you have to set up the validation folder to be like a type 1 dataset folder regardless of what type of dataset you're using in the training process