### PR TITLE
Add progress bar support to single audio file

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -32,7 +32,7 @@ def run_folder(model, args, config, device, verbose=False):
         os.mkdir(args.store_dir)
 
     if not verbose:
-        all_mixtures_path = tqdm(all_mixtures_path)
+        all_mixtures_path = tqdm(all_mixtures_path, desc="Total progress")
 
     for path in all_mixtures_path:
         if not verbose:


### PR DESCRIPTION
When I tried to process only one music, I noticed that the progress bar jumped from 0% directly to 100%. This happened because the progress bar was created based on the number of files.
To address this, I added a progress bar within the two processing functions to display the processing progress of a single audio file. I also set `leave=False`, so that when processing multiple audio files, the progress of each audio file is displayed without affecting the overall appearance. After testing (using the model `model_bs_roformer_ep_368_sdr_12.9628.ckpt`), I found that adding the progress bar did not significantly impact processing speed.
Here are some screenshots. The progress bar is updated every second.
![image](https://github.com/user-attachments/assets/7784240c-378f-4cdb-b569-8b0eb86c4ef9)
![image](https://github.com/user-attachments/assets/9c48649f-c50e-4135-a93a-bb2def74aa13)
