### PR TITLE
Add optional progress bar support

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -59,9 +59,9 @@ def run_folder(model, args, config, device, verbose=False):
 
         mixture = torch.tensor(mix, dtype=torch.float32)
         if args.model_type == 'htdemucs':
-            res = demix_track_demucs(config, model, mixture, device, pbar=True)
+            res = demix_track_demucs(config, model, mixture, device, pbar=args.detailed_pbar)
         else:
-            res = demix_track(config, model, mixture, device, pbar=True)
+            res = demix_track(config, model, mixture, device, pbar=args.detailed_pbar)
 
         for instr in instruments:
             estimates = res[instr].T
@@ -91,6 +91,7 @@ def proc_folder(args):
     parser.add_argument("--store_dir", default="", type=str, help="path to store results as wav file")
     parser.add_argument("--device_ids", nargs='+', type=int, default=0, help='list of gpu ids')
     parser.add_argument("--extract_instrumental", action='store_true', help="invert vocals to get instrumental if provided")
+    parser.add_argument("--detailed_pbar", action='store_true', help="show detailed progress bar")
     if args is None:
         args = parser.parse_args()
     else:

--- a/inference.py
+++ b/inference.py
@@ -32,7 +32,7 @@ def run_folder(model, args, config, device, verbose=False):
         os.mkdir(args.store_dir)
 
     if not verbose:
-        all_mixtures_path = tqdm(all_mixtures_path)
+        all_mixtures_path = tqdm(all_mixtures_path, desc="Total progress")
 
     for path in all_mixtures_path:
         if not verbose:
@@ -59,9 +59,9 @@ def run_folder(model, args, config, device, verbose=False):
 
         mixture = torch.tensor(mix, dtype=torch.float32)
         if args.model_type == 'htdemucs':
-            res = demix_track_demucs(config, model, mixture, device)
+            res = demix_track_demucs(config, model, mixture, device, pbar=True)
         else:
-            res = demix_track(config, model, mixture, device)
+            res = demix_track(config, model, mixture, device, pbar=True)
 
         for instr in instruments:
             estimates = res[instr].T

--- a/inference.py
+++ b/inference.py
@@ -34,6 +34,11 @@ def run_folder(model, args, config, device, verbose=False):
     if not verbose:
         all_mixtures_path = tqdm(all_mixtures_path, desc="Total progress")
 
+    if args.disable_detailed_pbar:
+        detailed_pbar = False
+    else:
+        detailed_pbar = True
+
     for path in all_mixtures_path:
         if not verbose:
             all_mixtures_path.set_postfix({'track': os.path.basename(path)})
@@ -59,9 +64,9 @@ def run_folder(model, args, config, device, verbose=False):
 
         mixture = torch.tensor(mix, dtype=torch.float32)
         if args.model_type == 'htdemucs':
-            res = demix_track_demucs(config, model, mixture, device, pbar=args.detailed_pbar)
+            res = demix_track_demucs(config, model, mixture, device, pbar=detailed_pbar)
         else:
-            res = demix_track(config, model, mixture, device, pbar=args.detailed_pbar)
+            res = demix_track(config, model, mixture, device, pbar=detailed_pbar)
 
         for instr in instruments:
             estimates = res[instr].T
@@ -91,7 +96,7 @@ def proc_folder(args):
     parser.add_argument("--store_dir", default="", type=str, help="path to store results as wav file")
     parser.add_argument("--device_ids", nargs='+', type=int, default=0, help='list of gpu ids')
     parser.add_argument("--extract_instrumental", action='store_true', help="invert vocals to get instrumental if provided")
-    parser.add_argument("--detailed_pbar", action='store_true', help="show detailed progress bar")
+    parser.add_argument("--disable_detailed_pbar", action='store_true', help="disable detailed progress bar")
     if args is None:
         args = parser.parse_args()
     else:


### PR DESCRIPTION
Hello! Based on your suggestion, I added the detailed progress bar as an optional feature. In the `demix_track()` and `demix_track_demucs()` functions, I added an optional parameter `pbar=False` at the end to control whether the detailed progress bar is displayed. Additionally, I added the `--detailed_pbar` option in the parser of `inference.py` to control whether the detailed progress bar is shown (if you think adding this option is unnecessary, I can remove it). Below are some screenshots. Thank you again!

Process with detailed pbar:
![20240805015542](https://github.com/user-attachments/assets/a365b100-0e2e-4f2b-8433-118fd44c66e2)
![20240805015806](https://github.com/user-attachments/assets/c0a42973-7294-4e00-8c9b-d2f7d69b85e9)