### PR TITLE
Add multiprocessing support for dataset type 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 __pycache__
 *.pyc
 .DS_Store
+data/
+results/


### PR DESCRIPTION
Generating metadata is significantly faster when parallel, it is implemented for other dataset types, but not for type 2.