### PR TITLE
Fix: Pin HuggingFace Hub version for stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ cover/
 # Jupyter Notebook
 .ipynb_checkpoints
 share/jupyter
+etc/jupyter
 
 # IPython
 profile_default/

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,14 +8,14 @@ tqdm
 segmentation_models_pytorch==0.3.3
 timm==0.9.2
 audiomentations==0.24.0
-pedalboard==0.8.1
+pedalboard~=0.8.1
 omegaconf==2.2.3
 beartype==0.14.1
 rotary_embedding_torch==0.3.5
 einops==0.6.1
 librosa
 demucs==4.0.0
-transformers==4.35.0
+transformers~=4.35.0
 torchmetrics==0.11.4
 spafe==0.3.2
 protobuf==3.20.3
@@ -26,3 +26,4 @@ torchseg
 bitsandbytes
 wandb
 accelerate
+huggingface-hub>=0.23.*


### PR DESCRIPTION
cannot import name 'split_torch_state_dict_into_shards' from 'huggingface_hub' #51 
ERROR: No matching distribution found for pedalboard==0.8.1