### PR TITLE
Fix bug: module must have its parameters and buffers on device cuda:0 (device_ids[0]) but found one of them on device: cpu

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -146,7 +146,7 @@ def proc_folder(args):
     elif torch.cuda.is_available():
         print('CUDA is available, use --force_cpu to disable it.')
         device = "cuda"
-        device = f'cuda:{args.device_ids}' if type(args.device_ids) == int else f'cuda:{args.device_ids[0]}'
+        device = f'cuda:{args.device_ids[0]}' if type(args.device_ids) == list else f'cuda:{args.device_ids}'
     elif torch.backends.mps.is_available():
         device = "mps"
 
@@ -169,7 +169,7 @@ def proc_folder(args):
     print("Instruments: {}".format(config.training.instruments))
 
     # in case multiple CUDA GPUs are used and --device_ids arg is passed
-    if type(args.device_ids) != int:
+    if type(args.device_ids) == list and len(args.device_ids) > 1 and not args.force_cpu:
         model = nn.DataParallel(model, device_ids = args.device_ids)
 
     model = model.to(device)


### PR DESCRIPTION
When using both `--device_ids 0` and `--force_cpu` simultaneously, the error `module must have its parameters and buffers on device cuda:0 (device_ids[0]) but found one of them on device: cpu` will be triggered. 
Additionally, even if the CPU is not used, but `--device_ids 0` is specified, due to the absence of a restriction on `len(args.device_ids) > 1`, device_ids will be [0] (a list type), which will lead to the execution of `model = nn.DataParallel(model, device_ids = args.device_ids)`, even though it’s not actually necessary.