### PR TITLE
remove duplicate code config.inference.normalize add missing code #68

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -59,14 +59,6 @@ def run_folder(model, args, config, device, verbose=False):
         if len(mix.shape) == 1:
             mix = np.stack([mix, mix], axis=0)
 
-        mix_orig = mix.copy()
-        if 'normalize' in config.inference:
-            if config.inference['normalize'] is True:
-                mono = mix.mean(0)
-                mean = mono.mean()
-                std = mono.std()
-                mix = (mix - mean) / std
-
         if args.use_tta:
             # orig, channel inverse, polarity inverse
             track_proc_list = [mix.copy(), mix[::-1].copy(), -1. * mix.copy()]
@@ -75,7 +67,7 @@ def run_folder(model, args, config, device, verbose=False):
 
         full_result = []
         for mix in track_proc_list:
-            waveforms = demix(config, model, mix, device, pbar=detailed_pbar, model_type=args.model_type)
+            waveforms = demix(config, model, mix, device, pbar=detailed_pbar, moduleArgs=args)
             full_result.append(waveforms)
 
         # Average all values in single dict
@@ -97,13 +89,10 @@ def run_folder(model, args, config, device, verbose=False):
             instr = 'vocals' if 'vocals' in instruments else instruments[0]
             instruments.append('instrumental')
             # Output "instrumental", which is an inverse of 'vocals' or the first stem in list if 'vocals' absent
-            waveforms['instrumental'] = mix_orig - waveforms[instr]
+            waveforms['instrumental'] = mix - waveforms[instr]
 
         for instr in instruments:
             estimates = waveforms[instr].T
-            if 'normalize' in config.inference:
-                if config.inference['normalize'] is True:
-                    estimates = estimates * std + mean
             file_name, _ = os.path.splitext(os.path.basename(path))
             if args.flac_file:
                 output_file = os.path.join(args.store_dir, f"{file_name}_{instr}.flac")

--- a/train.py
+++ b/train.py
@@ -179,14 +179,7 @@ def proc_list_of_files(
 
     for path in mixture_paths:
         mix, sr = sf.read(path)
-        mix_orig = mix.copy()
         mix = mix.T # (channels, waveform)
-        if 'normalize' in config.inference:
-            if config.inference['normalize'] is True:
-                mono = mix.mean(0)
-                mean = mono.mean()
-                std = mono.std()
-                mix = (mix - mean) / std
 
         folder = os.path.dirname(path)
         folder_name = os.path.abspath(folder)
@@ -205,7 +198,7 @@ def proc_list_of_files(
                 else:
                     # other is actually instrumental
                     track, sr1 = sf.read(folder + '/{}.wav'.format('vocals'))
-                    track = mix_orig - track
+                    track = mix - track
 
                 references = np.expand_dims(track, axis=0)
                 estimates = np.expand_dims(res[instr].T, axis=0)

--- a/utils.py
+++ b/utils.py
@@ -225,9 +225,35 @@ def sdr(references, estimates):
     den += delta
     return 10 * np.log10(num / den)
 
-def demix(config, model, mix: NDArray, device, pbar=False, model_type: str = None) -> Dict[str, NDArray]:
+def apply_normalize(demixFunction):
+    def normal_rapper(config, model, mix, device, pbar, moduleArgs, *args, **kwargs):
+        # Access 'normalize' from config, if available
+        normalize = getattr(config.inference, 'normalize', False)
+
+        # Handle normalization logic
+        if normalize:
+            print('Normalizing')
+            mono = mix.mean(0)
+            mean = mono.mean()
+            std = mono.std()
+            mix = (mix - mean) / std
+
+            dictionaryWaveforms = demixFunction(config, model, mix, device, pbar, moduleArgs, *args, **kwargs)
+
+            for instr, estimates in dictionaryWaveforms.items():
+                estimates = estimates * std + mean
+                dictionaryWaveforms[instr] = estimates
+        else:
+            dictionaryWaveforms = demixFunction(config, model, mix, device, pbar, moduleArgs, *args, **kwargs)
+
+        return dictionaryWaveforms
+    return normal_rapper
+
+@apply_normalize
+def demix(config, model, mix: NDArray, device, pbar=False, moduleArgs: dict = None) -> Dict[str, NDArray]:
     mix = torch.tensor(mix, dtype=torch.float32)
-    if model_type == 'htdemucs':
+    if moduleArgs.model_type == 'htdemucs':
         return demix_track_demucs(config, model, mix, device, pbar=pbar)
     else:
         return demix_track(config, model, mix, device, pbar=pbar)
+


### PR DESCRIPTION
https://github.com/ZFTurbo/Music-Source-Separation-Training/issues/68

It should be that @apply_normalize and @apply_use_tta can be decorated with or without the other and in any order.