### PR TITLE
Refactor directory creation logic

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -33,8 +33,7 @@ def run_folder(model, args, config, device, verbose=False):
     if config.training.target_instrument is not None:
         instruments = [config.training.target_instrument]
 
-    if not os.path.isdir(args.store_dir):
-        os.mkdir(args.store_dir)
+    os.makedirs(args.store_dir, exist_ok=True)
 
     if not verbose:
         all_mixtures_path = tqdm(all_mixtures_path, desc="Total progress")

--- a/train.py
+++ b/train.py
@@ -337,8 +337,7 @@ def train_model(args):
     model, config = get_model_from_config(args.model_type, args.config_path)
     print("Instruments: {}".format(config.training.instruments))
 
-    if not os.path.isdir(args.results_path):
-        os.mkdir(args.results_path)
+    os.makedirs(args.results_path, exist_ok=True)
 
     use_amp = True
     try:

--- a/train_accelerate.py
+++ b/train_accelerate.py
@@ -121,8 +121,7 @@ def train_model(args):
     model, config = get_model_from_config(args.model_type, args.config_path)
     accelerator.print("Instruments: {}".format(config.training.instruments))
 
-    if not os.path.isdir(args.results_path):
-        os.mkdir(args.results_path)
+    os.makedirs(args.results_path, exist_ok=True)
 
     device_ids = args.device_ids
     batch_size = config.training.batch_size

--- a/valid.py
+++ b/valid.py
@@ -34,8 +34,7 @@ def proc_list_of_files(
         instruments = [config.training.target_instrument]
 
     if args.store_dir != "":
-        if not os.path.isdir(args.store_dir):
-            os.mkdir(args.store_dir)
+        os.makedirs(args.store_dir, exist_ok=True)
 
     all_sdr = dict()
     for instr in config.training.instruments:


### PR DESCRIPTION
os.makedirs is "Super-mkdir; create a leaf directory and all intermediate ones. Works like mkdir, except that any intermediate path segment (not just the rightmost) will be created if it does not exist. If the target directory already exists [and `exist_ok=True`] no exception is raised."