### PR TITLE
Optimize train

### DIFF
--- a/train.py
+++ b/train.py
@@ -20,7 +20,9 @@ from torch.optim import Adam, AdamW, SGD, RAdam, RMSprop
 from torch.utils.data import DataLoader
 from torch.cuda.amp.grad_scaler import GradScaler
 from torch.optim.lr_scheduler import ReduceLROnPlateau
+from ml_collections import ConfigDict
 import torch.nn.functional as F
+from typing import List, Tuple, Dict, Union, Callable
 
 from dataset import MSSDataset
 from utils import demix, sdr, get_model_from_config
@@ -31,19 +33,63 @@ import warnings
 warnings.filterwarnings("ignore")
 
 
-def masked_loss(y_, y, q, coarse=True):
-    # shape = [num_sources, batch_size, num_channels, chunk_size]
-    loss = torch.nn.MSELoss(reduction='none')(y_, y).transpose(0, 1)
-    if coarse:
-        loss = torch.mean(loss, dim=(-1, -2))
-    loss = loss.reshape(loss.shape[0], -1)
-    L = loss.detach()
-    quantile = torch.quantile(L, q, interpolation='linear', dim=1, keepdim=True)
-    mask = L < quantile
-    return (loss * mask).mean()
+def parse_args(args: List[str] | None) -> argparse.Namespace:
+    """
+    Parse command-line arguments for configuring the model, dataset, and training parameters.
+
+    Args:
+        args: List of command-line arguments. If None, arguments will be parsed from sys.argv.
+
+    Returns:
+        Namespace object containing parsed arguments and their values.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_type", type=str, default='mdx23c',
+                        help="One of mdx23c, htdemucs, segm_models, mel_band_roformer, bs_roformer, swin_upernet, bandit")
+    parser.add_argument("--config_path", type=str, help="path to config file")
+    parser.add_argument("--start_check_point", type=str, default='', help="Initial checkpoint to start training")
+    parser.add_argument("--results_path", type=str,
+                        help="path to folder where results will be stored (weights, metadata)")
+    parser.add_argument("--data_path", nargs="+", type=str, help="Dataset data paths. You can provide several folders.")
+    parser.add_argument("--dataset_type", type=int, default=1,
+                        help="Dataset type. Must be one of: 1, 2, 3 or 4. Details here: https://github.com/ZFTurbo/Music-Source-Separation-Training/blob/main/docs/dataset_types.md")
+    parser.add_argument("--valid_path", nargs="+", type=str,
+                        help="validation data paths. You can provide several folders.")
+    parser.add_argument("--num_workers", type=int, default=0, help="dataloader num_workers")
+    parser.add_argument("--pin_memory", type=bool, default=False, help="dataloader pin_memory")
+    parser.add_argument("--seed", type=int, default=0, help="random seed")
+    parser.add_argument("--device_ids", nargs='+', type=int, default=[0], help='list of gpu ids')
+    parser.add_argument("--use_multistft_loss", action='store_true', help="Use MultiSTFT Loss (from auraloss package)")
+    parser.add_argument("--use_mse_loss", action='store_true', help="Use default MSE loss")
+    parser.add_argument("--use_l1_loss", action='store_true', help="Use L1 loss")
+    parser.add_argument("--wandb_key", type=str, default='', help='wandb API Key')
+    parser.add_argument("--pre_valid", action='store_true', help='Run validation before training')
+    parser.add_argument("--metrics", nargs='+', type=str, default=["sdr"],
+                        choices=['sdr', 'l1_freq', 'si_sdr', 'neg_log_wmse', 'aura_stft', 'aura_mrstft', 'bleedless',
+                                 'fullness'], help='List of metrics to use.')
+    parser.add_argument("--metric_for_scheduler", default="sdr",
+                        choices=['sdr', 'l1_freq', 'si_sdr', 'neg_log_wmse', 'aura_stft', 'aura_mrstft', 'bleedless',
+                                 'fullness'], help='Metric which will be used for scheduler.')
+    if args is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(args)
+
+    if args.metric_for_scheduler not in args.metrics:
+        args.metrics += [args.metric_for_scheduler]
+
+    print(f'Type args:{type(args)}')
+    return args
 
 
-def manual_seed(seed):
+def manual_seed(seed: int) -> None:
+    """
+    Set the random seed for reproducibility across Python, NumPy, and PyTorch.
+
+    Args:
+        seed: The seed value to set.
+    """
+
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
@@ -53,7 +99,80 @@ def manual_seed(seed):
     os.environ["PYTHONHASHSEED"] = str(seed)
 
 
-def load_not_compatible_weights(model, weights, verbose=False):
+def initialize_environment(seed: int, results_path: str) -> None:
+    """
+    Initialize the environment by setting the random seed, configuring PyTorch settings,
+    and creating the results directory.
+
+    Args:
+        seed: The seed value for reproducibility.
+        results_path: Path to the directory where results will be stored.
+    """
+
+    manual_seed(seed)
+    torch.backends.cudnn.deterministic = False
+    torch.multiprocessing.set_start_method('spawn')
+    os.makedirs(results_path, exist_ok=True)
+
+def wandb_init(args: argparse.Namespace, config: Dict, device_ids: List[int], batch_size: int) -> None:
+    """
+    Initialize the Weights & Biases (wandb) logging system.
+
+    Args:
+        args: Parsed command-line arguments containing the wandb key.
+        config: Configuration dictionary for the experiment.
+        device_ids: List of GPU device IDs used for training.
+        batch_size: Batch size for training.
+    """
+
+    if args.wandb_key is None or args.wandb_key.strip() == '':
+        wandb.init(mode='disabled')
+    else:
+        wandb.login(key=args.wandb_key)
+        wandb.init(project='msst', config={'config': config, 'args': args, 'device_ids': device_ids, 'batch_size': batch_size })
+
+
+def prepare_data(config: Dict, args: argparse.Namespace, batch_size: int) -> DataLoader:
+    """
+    Prepare the training dataset and data loader.
+
+    Args:
+        config: Configuration dictionary for the dataset.
+        args: Parsed command-line arguments containing dataset paths and settings.
+        batch_size: Batch size for training.
+
+    Returns:
+        DataLoader object for the training dataset.
+    """
+
+    trainset = MSSDataset(
+        config,
+        args.data_path,
+        batch_size=batch_size,
+        metadata_path=os.path.join(args.results_path, f'metadata_{args.dataset_type}.pkl'),
+        dataset_type=args.dataset_type,
+    )
+
+    train_loader = DataLoader(
+        trainset,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+        pin_memory=args.pin_memory
+    )
+    return train_loader
+
+
+def load_not_compatible_weights(model: torch.nn.Module, weights: str, verbose: bool = False) -> None:
+    """
+    Load weights into a model, handling mismatched shapes and dimensions.
+
+    Args:
+        model: PyTorch model into which the weights will be loaded.
+        weights: Path to the weights file.
+        verbose: If True, prints detailed information about matching and mismatched layers.
+    """
+
     new_model = model.state_dict()
     old_model = torch.load(weights)
     if 'state' in old_model:
@@ -103,93 +222,371 @@ def load_not_compatible_weights(model, weights, verbose=False):
     )
 
 
-def train_model(args):
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--model_type", type=str, default='mdx23c', help="One of mdx23c, htdemucs, segm_models, mel_band_roformer, bs_roformer, swin_upernet, bandit")
-    parser.add_argument("--config_path", type=str, help="path to config file")
-    parser.add_argument("--start_check_point", type=str, default='', help="Initial checkpoint to start training")
-    parser.add_argument("--results_path", type=str, help="path to folder where results will be stored (weights, metadata)")
-    parser.add_argument("--data_path", nargs="+", type=str, help="Dataset data paths. You can provide several folders.")
-    parser.add_argument("--dataset_type", type=int, default=1, help="Dataset type. Must be one of: 1, 2, 3 or 4. Details here: https://github.com/ZFTurbo/Music-Source-Separation-Training/blob/main/docs/dataset_types.md")
-    parser.add_argument("--valid_path", nargs="+", type=str, help="validation data paths. You can provide several folders.")
-    parser.add_argument("--num_workers", type=int, default=0, help="dataloader num_workers")
-    parser.add_argument("--pin_memory", type=bool, default=False, help="dataloader pin_memory")
-    parser.add_argument("--seed", type=int, default=0, help="random seed")
-    parser.add_argument("--device_ids", nargs='+', type=int, default=[0], help='list of gpu ids')
-    parser.add_argument("--use_multistft_loss", action='store_true', help="Use MultiSTFT Loss (from auraloss package)")
-    parser.add_argument("--use_mse_loss", action='store_true', help="Use default MSE loss")
-    parser.add_argument("--use_l1_loss", action='store_true', help="Use L1 loss")
-    parser.add_argument("--wandb_key", type=str, default='', help='wandb API Key')
-    parser.add_argument("--pre_valid", action='store_true', help='Run validation before training')
-    parser.add_argument("--metrics", nargs='+', type=str, default=["sdr"], choices=['sdr', 'l1_freq', 'si_sdr', 'log_wmse', 'aura_stft', 'aura_mrstft', 'bleedless', 'fullness'], help='List of metrics to use.')
-    parser.add_argument("--metric_for_scheduler", default="sdr", choices=['sdr', 'l1_freq', 'si_sdr', 'log_wmse', 'aura_stft', 'aura_mrstft', 'bleedless', 'fullness'], help='Metric which will be used for scheduler.')
-    if args is None:
-        args = parser.parse_args()
+def load_start_checkpoint(args: argparse.Namespace, model: torch.nn.Module) -> None:
+    """
+    Load the starting checkpoint for a model.
+
+    Args:
+        args: Parsed command-line arguments containing the checkpoint path.
+        model: PyTorch model to load the checkpoint into.
+    """
+
+    print(f'Start from checkpoint: {args.start_check_point}')
+    if 1:
+        load_not_compatible_weights(model, args.start_check_point, verbose=False)
     else:
-        args = parser.parse_args(args)
+        model.load_state_dict(torch.load(args.start_check_point))
 
-    manual_seed(args.seed + int(time.time()))
-    # torch.backends.cudnn.benchmark = True
-    torch.backends.cudnn.deterministic = False # Fix possible slow down with dilation convolutions
-    torch.multiprocessing.set_start_method('spawn')
 
-    model, config = get_model_from_config(args.model_type, args.config_path)
-    print(f"Instruments: {config.training.instruments}")
+def initialize_model_and_device(model: torch.nn.Module, device_ids: List[int]) -> Tuple[torch.device | str, torch.nn.Module]:
+    """
+    Initialize the model and assign it to the appropriate device (GPU or CPU).
 
-    if args.metric_for_scheduler not in args.metrics:
-        args.metrics += [args.metric_for_scheduler]
-    print(f'Metrics for training: {args.metrics}. Metric for scheduler: {args.metric_for_scheduler}')
+    Args:
+        model: The PyTorch model to be initialized.
+        device_ids: List of GPU device IDs to use for parallel processing.
 
-    os.makedirs(args.results_path, exist_ok=True)
-
-    use_amp = config.training.get(key='use_amp', default=True)
-
-    device_ids = args.device_ids
-    batch_size = config.training.batch_size * len(device_ids)
-
-    # wandb
-    if args.wandb_key is None or args.wandb_key.strip() == '':
-        wandb.init(mode='disabled')
-    else:
-        wandb.login(key=args.wandb_key)
-        wandb.init(project='msst', config={'config': config, 'args': args, 'device_ids': device_ids, 'batch_size': batch_size })
-
-    trainset = MSSDataset(
-        config,
-        args.data_path,
-        batch_size=batch_size,
-        metadata_path = os.path.join(args.results_path, f'metadata_{args.dataset_type}.pkl'),
-        dataset_type=args.dataset_type,
-    )
-
-    train_loader = DataLoader(
-        trainset,
-        batch_size=batch_size,
-        shuffle=True,
-        num_workers=args.num_workers,
-        pin_memory=args.pin_memory
-    )
-
-    if args.start_check_point != '':
-        print(f'Start from checkpoint: {args.start_check_point}')
-        if 1:
-            load_not_compatible_weights(model, args.start_check_point, verbose=False)
-        else:
-            model.load_state_dict(torch.load(args.start_check_point))
+    Returns:
+        A tuple containing the device and the model moved to that device.
+    """
 
     if torch.cuda.is_available():
         if len(device_ids) <= 1:
-            print(f'Use single GPU: {device_ids}')
             device = torch.device(f'cuda:{device_ids[0]}')
             model = model.to(device)
         else:
-            print(f'Use multi GPU: {device_ids}')
             device = torch.device(f'cuda:{device_ids[0]}')
             model = nn.DataParallel(model, device_ids=device_ids).to(device)
     else:
         device = 'cpu'
-        print('CUDA is not avilable. Run training on CPU. It will be very slow...')
-        model = model.to(device)
+        model = device, model.to(device)
+        print("CUDA is not available. Running on CPU.")
+
+    return device, model
+
+
+def get_optimizer(config: ConfigDict, model: torch.nn.Module) -> torch.optim.Optimizer:
+    """
+    Initializes an optimizer based on the configuration.
+
+    Args:
+        config: Configuration object containing training parameters.
+        model: PyTorch model whose parameters will be optimized.
+
+    Returns:
+        A PyTorch optimizer object configured based on the specified settings.
+    """
+
+    optim_params = dict()
+    if 'optimizer' in config:
+        optim_params = dict(config['optimizer'])
+        print(f'Optimizer params from config:\n{optim_params}')
+
+    name_optimizer = getattr(config.training, 'optimizer',
+                             'No optimizer in config')
+
+    if name_optimizer == 'adam':
+        optimizer = Adam(model.parameters(), lr=config.training.lr, **optim_params)
+    elif name_optimizer == 'adamw':
+        optimizer = AdamW(model.parameters(), lr=config.training.lr, **optim_params)
+    elif name_optimizer == 'radam':
+        optimizer = RAdam(model.parameters(), lr=config.training.lr, **optim_params)
+    elif name_optimizer == 'rmsprop':
+        optimizer = RMSprop(model.parameters(), lr=config.training.lr, **optim_params)
+    elif name_optimizer == 'prodigy':
+        from prodigyopt import Prodigy
+        # you can choose weight decay value based on your problem, 0 by default
+        # We recommend using lr=1.0 (default) for all networks.
+        optimizer = Prodigy(model.parameters(), lr=config.training.lr, **optim_params)
+    elif name_optimizer == 'adamw8bit':
+        import bitsandbytes as bnb
+        optimizer = bnb.optim.AdamW8bit(model.parameters(), lr=config.training.lr, **optim_params)
+    elif name_optimizer == 'sgd':
+        print('Use SGD optimizer')
+        optimizer = SGD(model.parameters(), lr=config.training.lr, **optim_params)
+    else:
+        print(f'Unknown optimizer: {name_optimizer}')
+        exit()
+    return optimizer
+
+
+def masked_loss(y_: torch.Tensor, y: torch.Tensor, q: float, coarse: bool = True) -> torch.Tensor:
+    """
+    Compute the masked loss, which applies a quantile-based mask to the MSE loss.
+
+    Args:
+        y_: Predicted tensor of shape [num_sources, batch_size, num_channels, chunk_size].
+        y: Ground truth tensor of the same shape as y_.
+        q: Quantile value for the mask.
+        coarse: If True, computes the mean loss over the last two dimensions (channels and chunk_size).
+
+    Returns:
+        The masked mean loss.
+    """
+
+    # shape = [num_sources, batch_size, num_channels, chunk_size]
+    loss = torch.nn.MSELoss(reduction='none')(y_, y).transpose(0, 1)
+    if coarse:
+        loss = torch.mean(loss, dim=(-1, -2))
+    loss = loss.reshape(loss.shape[0], -1)
+    L = loss.detach()
+    quantile = torch.quantile(L, q, interpolation='linear', dim=1, keepdim=True)
+    mask = L < quantile
+    return (loss * mask).mean()
+
+
+def multistft_loss(y: torch.Tensor, y_: torch.Tensor, loss_multistft: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]) -> torch.Tensor:
+    """
+    Compute the multi-STFT loss between the predicted and ground truth tensors.
+
+    Args:
+        y: Ground truth tensor, shape [num_sources, batch_size, num_channels, chunk_size] (or [num_sources, batch_size, chunk_size] for models like Apollo).
+        y_: Predicted tensor with the same shape as y.
+        loss_multistft: A function that computes the multi-STFT loss.
+
+    Returns:
+        The multi-STFT loss value.
+    """
+
+    if len(y_.shape) == 4:
+        y1_ = torch.reshape(y_, (y_.shape[0], y_.shape[1] * y_.shape[2], y_.shape[3]))
+        y1 = torch.reshape(y, (y.shape[0], y.shape[1] * y.shape[2], y.shape[3]))
+    elif len(y_.shape) == 3:
+        # For models like apollo no need to reshape
+        y1_ = y_
+        y1 = y
+    else:
+        raise ValueError(f"Invalid shape for predicted array: {y_.shape}. Expected 3 or 4 dimensions.")
+
+    return loss_multistft(y1_, y1)
+
+
+def choice_loss(args: argparse.Namespace, config: ConfigDict) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor]:
+    """
+    Select and return the appropriate loss function based on the configuration and arguments.
+
+    Args:
+        args: Parsed command-line arguments containing flags for different loss functions.
+        config: Configuration object containing loss settings and parameters.
+
+    Returns:
+        A loss function that can be applied to the predicted and ground truth tensors.
+    """
+
+    if args.use_multistft_loss:
+        loss_options = dict(config.get(key='loss_multistft', default={}))
+        print(f'Loss options: {loss_options}')
+        loss_multistft = auraloss.freq.MultiResolutionSTFTLoss(**loss_options)
+
+        if args.use_mse_loss and args.use_l1_loss:
+            def multi_loss(y_, y):
+                return (multistft_loss(y_, y, loss_multistft) / 1000) + nn.MSELoss()(y_, y) + F.l1_loss(y_, y)
+        elif args.use_mse_loss:
+            def multi_loss(y_, y):
+                return (multistft_loss(y_, y, loss_multistft) / 1000) + nn.MSELoss()(y_, y)
+        elif args.use_l1_loss:
+            def multi_loss(y_, y):
+                return (multistft_loss(y_, y, loss_multistft) / 1000) + F.l1_loss(y_, y)
+        else:
+            def multi_loss(y_, y):
+                return multistft_loss(y_, y, loss_multistft) / 1000
+    elif args.use_mse_loss:
+        if args.use_l1_loss:
+            def multi_loss(y_, y):
+                return nn.MSELoss()(y_, y) + F.l1_loss(y_, y)
+        else:
+            multi_loss = nn.MSELoss()
+    elif args.use_l1_loss:
+        multi_loss = F.l1_loss
+    else:
+        def multi_loss(y_, y):
+            return masked_loss(y_, y, q=config.training.q, coarse=config.training.coarse_loss_clip)
+    return multi_loss
+
+
+def normalize_batch(x: torch.Tensor, y: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Normalize a batch of tensors (x and y) by subtracting the mean and dividing by the standard deviation.
+
+    Args:
+        x: Tensor to normalize.
+        y: Tensor to normalize (same as x, typically).
+
+    Returns:
+        A tuple of normalized tensors (x, y).
+    """
+
+    mean = x.mean()
+    std = x.std()
+    if std != 0:
+        x = (x - mean) / std
+        y = (y - mean) / std
+    return x, y
+
+
+def train_one_epoch(model: torch.nn.Module, config: ConfigDict, args: argparse.Namespace, optimizer: torch.optim.Optimizer,
+                    device: torch.device, device_ids: List[int], epoch: int, use_amp: bool, scaler: torch.cuda.amp.GradScaler,
+                    gradient_accumulation_steps: int, train_loader: torch.utils.data.DataLoader,
+                    multi_loss: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]) -> None:
+    """
+    Train the model for one epoch.
+
+    Args:
+        model: The model to train.
+        config: Configuration object containing training parameters.
+        args: Command-line arguments with specific settings (e.g., model type).
+        optimizer: Optimizer used for training.
+        device: Device to run the model on (CPU or GPU).
+        device_ids: List of GPU device IDs if using multiple GPUs.
+        epoch: The current epoch number.
+        use_amp: Whether to use automatic mixed precision (AMP) for training.
+        scaler: Scaler for AMP to manage gradient scaling.
+        gradient_accumulation_steps: Number of gradient accumulation steps before updating the optimizer.
+        train_loader: DataLoader for the training dataset.
+        multi_loss: The loss function to use during training.
+
+    Returns:
+        None
+    """
+
+    model.train().to(device)
+    print(f'Train epoch: {epoch} Learning rate: {optimizer.param_groups[0]["lr"]}')
+    loss_val = 0.
+    total = 0
+
+    normalize = config.training.get('normalize', False)
+
+    pbar = tqdm(train_loader)
+    for i, (batch, mixes) in enumerate(pbar):
+        x = mixes.to(device)  # mixture
+        y = batch.to(device)
+
+        if normalize:
+            x, y = normalize_batch(x, y)
+
+        with torch.cuda.amp.autocast(enabled=use_amp):
+            if args.model_type in ['mel_band_roformer', 'bs_roformer']:
+                # loss is computed in forward pass
+                loss = model(x, y)
+                if isinstance(device_ids, (list, tuple)):
+                    # If it's multiple GPUs sum partial loss
+                    loss = loss.mean()
+            else:
+                y_ = model(x)
+                loss = multi_loss(y_, y)
+
+        loss /= gradient_accumulation_steps
+        scaler.scale(loss).backward()
+        if config.training.grad_clip:
+            nn.utils.clip_grad_norm_(model.parameters(), config.training.grad_clip)
+
+        if ((i + 1) % gradient_accumulation_steps == 0) or (i == len(train_loader) - 1):
+            scaler.step(optimizer)
+            scaler.update()
+            optimizer.zero_grad(set_to_none=True)
+
+        li = loss.item() * gradient_accumulation_steps
+        loss_val += li
+        total += 1
+        pbar.set_postfix({'loss': 100 * li, 'avg_loss': 100 * loss_val / (i + 1)})
+        wandb.log({'loss': 100 * li, 'avg_loss': 100 * loss_val / (i + 1), 'i': i})
+        loss.detach()
+
+    print(f'Training loss: {loss_val / total}')
+    wandb.log({'train_loss': loss_val / total, 'epoch': epoch, 'learning_rate': optimizer.param_groups[0]['lr']})
+
+
+def save_weights(store_path, model, device_ids):
+    state_dict = model.state_dict() if len(device_ids) <= 1 else model.module.state_dict()
+    torch.save(
+        state_dict,
+        store_path
+    )
+
+
+def save_last_weights(args: argparse.Namespace, model: torch.nn.Module, device_ids: List[int]) -> None:
+    """
+    Save the model's state_dict to a file for later use.
+
+    Args:
+        args: Command-line arguments containing the results path and model type.
+        model: The model whose weights will be saved.
+        device_ids: List of GPU device IDs if using multiple GPUs.
+
+    Returns:
+        None
+    """
+
+    store_path = f'{args.results_path}/last_{args.model_type}.ckpt'
+    save_weights(store_path, model, device_ids)
+
+
+def compute_epoch_metrics(model: torch.nn.Module, args: argparse.Namespace, config: ConfigDict,
+                          device: torch.device, device_ids: List[int], best_metric: float,
+                          epoch: int, scheduler: torch.optim.lr_scheduler._LRScheduler) -> float:
+    """
+    Compute and log the metrics for the current epoch, and save model weights if the metric improves.
+
+    Args:
+        model: The model to evaluate.
+        args: Command-line arguments containing configuration paths and other settings.
+        config: Configuration dictionary containing training settings.
+        device: The device (CPU or GPU) used for evaluation.
+        device_ids: List of GPU device IDs when using multiple GPUs.
+        best_metric: The best metric value seen so far.
+        epoch: The current epoch number.
+        scheduler: The learning rate scheduler to adjust the learning rate.
+
+    Returns:
+        The updated best_metric.
+    """
+
+    if torch.cuda.is_available() and len(device_ids) > 1:
+        metrics_avg = valid_multi_gpu(model, args, config, args.device_ids, verbose=False)
+    else:
+        metrics_avg = valid(model, args, config, device, verbose=False)
+    metric_avg = metrics_avg[args.metric_for_scheduler]
+    if metric_avg > best_metric:
+        store_path = f'{args.results_path}/model_{args.model_type}_ep_{epoch}_{args.metric_for_scheduler}_{metric_avg:.4f}.ckpt'
+        print(f'Store weights: {store_path}')
+        save_weights(store_path, model, device_ids)
+        best_metric = metric_avg
+    scheduler.step(metric_avg)
+    wandb.log({'metric_main': metric_avg, 'best_metric': best_metric})
+    for metric_name in metrics_avg:
+        wandb.log({f'metric_{metric_name}': metrics_avg[metric_name]})
+
+    return best_metric
+
+
+def train_model(args: argparse.Namespace) -> None:
+    """
+    Trains the model based on the provided arguments, including data preparation, optimizer setup,
+    and loss calculation. The model is trained for multiple epochs with logging via wandb.
+
+    Args:
+        args: Command-line arguments containing configuration paths, hyperparameters, and other settings.
+
+    Returns:
+        None
+    """
+
+    args = parse_args(args)
+
+    initialize_environment(args.seed, args.results_path)
+    model, config = get_model_from_config(args.model_type, args.config_path)
+    use_amp = config.training.get(key='use_amp', default=True)
+    device_ids = args.device_ids
+    batch_size = config.training.batch_size * len(device_ids)
+
+    wandb_init(args, config, device_ids, batch_size)
+
+    train_loader = prepare_data(config, args, batch_size)
+
+    if args.start_check_point:
+        load_start_checkpoint(args, model)
+
+    device, model = initialize_model_and_device(model, args.device_ids)
 
     if args.pre_valid:
         if torch.cuda.is_available() and len(device_ids) > 1:
@@ -197,158 +594,36 @@ def train_model(args):
         else:
             valid(model, args, config, device, verbose=True)
 
-    optim_params = dict()
-    if 'optimizer' in config:
-        optim_params = dict(config['optimizer'])
-        print(f'Optimizer params from config:\n{optim_params}')
-
-    if config.training.optimizer == 'adam':
-        optimizer = Adam(model.parameters(), lr=config.training.lr, **optim_params)
-    elif config.training.optimizer == 'adamw':
-        optimizer = AdamW(model.parameters(), lr=config.training.lr, **optim_params)
-    elif config.training.optimizer == 'radam':
-        optimizer = RAdam(model.parameters(), lr=config.training.lr, **optim_params)
-    elif config.training.optimizer == 'rmsprop':
-        optimizer = RMSprop(model.parameters(), lr=config.training.lr, **optim_params)
-    elif config.training.optimizer == 'prodigy':
-        from prodigyopt import Prodigy
-        # you can choose weight decay value based on your problem, 0 by default
-        # We recommend using lr=1.0 (default) for all networks.
-        optimizer = Prodigy(model.parameters(), lr=config.training.lr, **optim_params)
-    elif config.training.optimizer == 'adamw8bit':
-        import bitsandbytes as bnb
-        optimizer = bnb.optim.AdamW8bit(model.parameters(), lr=config.training.lr, **optim_params)
-    elif config.training.optimizer == 'sgd':
-        print('Use SGD optimizer')
-        optimizer = SGD(model.parameters(), lr=config.training.lr, **optim_params)
-    else:
-        print(f'Unknown optimizer: {config.training.optimizer}')
-        exit()
-
+    optimizer = get_optimizer(config, model)
     gradient_accumulation_steps = int(config.training.get(key='gradient_accumulation_steps', default=1))
 
+    # Reduce LR if no metric improvements for several epochs
+    scheduler = ReduceLROnPlateau(optimizer, 'max', patience=config.training.patience,
+                                  factor=config.training.reduce_factor)
+
+    multi_loss = choice_loss(args, config)
+    scaler = GradScaler()
+    best_metric = float('inf')
+
     print(
-        f"Patience: {config.training.patience} "
-        f"Reduce factor: {config.training.reduce_factor} "
-        f"Batch size: {batch_size} "
-        f"Grad accum steps: {gradient_accumulation_steps} "
-        f"Effective batch size: {batch_size * gradient_accumulation_steps} "
+        f"Instruments: {config.training.instruments}\n"
+        f"Metrics for training: {args.metrics}. Metric for scheduler: {args.metric_for_scheduler}\n"
+        f"Patience: {config.training.patience}\n"
+        f"Reduce factor: {config.training.reduce_factor}\n"
+        f"Batch size: {batch_size}\n"
+        f"Grad accum steps: {gradient_accumulation_steps}\n"
+        f"Effective batch size: {batch_size * gradient_accumulation_steps}\n"
         f"Optimizer: {config.training.optimizer}"
     )
-    # Reduce LR if no metric improvements for several epochs
-    scheduler = ReduceLROnPlateau(optimizer, 'max', patience=config.training.patience, factor=config.training.reduce_factor)
 
-    if args.use_multistft_loss:
-        loss_options = dict(config.get(key='loss_multistft', default={}))
-        print(f'Loss options: {loss_options}')
-        loss_multistft = auraloss.freq.MultiResolutionSTFTLoss(
-            **loss_options
-        )
-
-    scaler = GradScaler()
     print(f'Train for: {config.training.num_epochs} epochs')
-    best_metric = -10000
+
     for epoch in range(config.training.num_epochs):
-        model.train().to(device)
-        print(f'Train epoch: {epoch} Learning rate: {optimizer.param_groups[0]["lr"]}')
-        loss_val = 0.
-        total = 0
 
-        # total_loss = None
-        pbar = tqdm(train_loader)
-        for i, (batch, mixes) in enumerate(pbar):
-            y = batch.to(device)
-            x = mixes.to(device)  # mixture
-
-            if 'normalize' in config.training:
-                if config.training.normalize:
-                    mean = x.mean()
-                    std = x.std()
-                    if std != 0:
-                        x = (x - mean) / std
-                        y = (y - mean) / std
-
-            with torch.cuda.amp.autocast(enabled=use_amp):
-                if args.model_type in ['mel_band_roformer', 'bs_roformer']:
-                    # loss is computed in forward pass
-                    loss = model(x, y)
-                    if type(device_ids) != int:
-                        # If it's multiple GPUs sum partial loss
-                        loss = loss.mean()
-                else:
-                    y_ = model(x)
-                    if args.use_multistft_loss:
-                        if len(y_.shape) == 3:
-                            # For models like apollo no need to reshape
-                            y1_ = y_
-                            y1 = y
-                        else:
-                            y1_ = torch.reshape(y_, (y_.shape[0], y_.shape[1] * y_.shape[2], y_.shape[3]))
-                            y1 = torch.reshape(y, (y.shape[0], y.shape[1] * y.shape[2], y.shape[3]))
-                        loss = loss_multistft(y1_, y1)
-                        # We can use many losses at the same time
-                        if args.use_mse_loss:
-                            loss += 1000 * nn.MSELoss()(y1_, y1)
-                        if args.use_l1_loss:
-                            loss += 1000 * F.l1_loss(y1_, y1)
-                    elif args.use_mse_loss:
-                        loss = nn.MSELoss()(y_, y)
-                    elif args.use_l1_loss:
-                        loss = F.l1_loss(y_, y)
-                    else:
-                        loss = masked_loss(
-                            y_,
-                            y,
-                            q=config.training.q,
-                            coarse=config.training.coarse_loss_clip
-                        )
-
-            loss /= gradient_accumulation_steps
-            scaler.scale(loss).backward()
-            if config.training.grad_clip:
-                nn.utils.clip_grad_norm_(model.parameters(), config.training.grad_clip)
-
-            if ((i + 1) % gradient_accumulation_steps == 0) or (i == len(train_loader) - 1):
-                scaler.step(optimizer)
-                scaler.update()
-                optimizer.zero_grad(set_to_none=True)
-
-            li = loss.item() * gradient_accumulation_steps
-            loss_val += li
-            total += 1
-            pbar.set_postfix({'loss': 100 * li, 'avg_loss': 100 * loss_val / (i + 1)})
-            wandb.log({'loss': 100 * li, 'avg_loss': 100 * loss_val / (i + 1), 'i': i})
-            loss.detach()
-
-        print(f'Training loss: {loss_val / total:.6f}')
-        wandb.log({'train_loss': loss_val / total, 'epoch': epoch, 'learning_rate': optimizer.param_groups[0]['lr']})
-
-        # Save last
-        store_path = f'{args.results_path}/last_{args.model_type}.ckpt'
-        state_dict = model.state_dict() if len(device_ids) <= 1 else model.module.state_dict()
-        torch.save(
-            state_dict,
-            store_path
-        )
-
-        if torch.cuda.is_available() and len(device_ids) > 1:
-            metrics_avg = valid_multi_gpu(model, args, config, args.device_ids, verbose=False)
-        else:
-            metrics_avg = valid(model, args, config, device, verbose=False)
-        metric_avg = metrics_avg[args.metric_for_scheduler]
-        if metric_avg > best_metric:
-            store_path = f'{args.results_path}/model_{args.model_type}_ep_{epoch}_{args.metric_for_scheduler}_{metric_avg:.4f}.ckpt'
-            print(f'Store weights: {store_path}')
-            state_dict = model.state_dict() if len(device_ids) <= 1 else model.module.state_dict()
-            torch.save(
-                state_dict,
-                store_path
-            )
-            best_metric = metric_avg
-        scheduler.step(metric_avg)
-        wandb.log({'metric_main': metric_avg, 'best_metric': best_metric})
-        for metric_name in metrics_avg:
-            wandb.log({f'metric_{metric_name}': metrics_avg[metric_name]})
+        train_one_epoch(model, config, args, optimizer, device, device_ids, epoch,
+                         use_amp, scaler, gradient_accumulation_steps, train_loader, multi_loss)
+        save_last_weights(args, model, device_ids)
+        best_metric = compute_epoch_metrics(model, args, config, device, device_ids, best_metric, epoch, scheduler)
 
 
 if __name__ == "__main__":

--- a/train.py
+++ b/train.py
@@ -602,7 +602,7 @@ def train_model(args: argparse.Namespace) -> None:
 
     multi_loss = choice_loss(args, config)
     scaler = GradScaler()
-    best_metric = float('inf')
+    best_metric = float('-inf')
 
     print(
         f"Instruments: {config.training.instruments}\n"

--- a/train.py
+++ b/train.py
@@ -78,7 +78,6 @@ def parse_args(args: List[str] | None) -> argparse.Namespace:
     if args.metric_for_scheduler not in args.metrics:
         args.metrics += [args.metric_for_scheduler]
 
-    print(f'Type args:{type(args)}')
     return args
 
 

--- a/utils.py
+++ b/utils.py
@@ -10,10 +10,10 @@ import torch.nn.functional as F
 from ml_collections import ConfigDict
 from omegaconf import OmegaConf
 from tqdm.auto import tqdm
-from typing import Dict, List, Tuple, Any
+from typing import Dict, List, Tuple, Any, Union
 
 
-def load_config(model_type: str, config_path: str) -> Any:
+def load_config(model_type: str, config_path: str) -> Union[ConfigDict, OmegaConf]:
     """
     Load the configuration from the specified path based on the model type.
 
@@ -420,7 +420,7 @@ def L1Freq_metric(
     return ret
 
 
-def LogWMSE_metric(
+def NegLogWMSE_metric(
         reference: np.ndarray,
         estimate: np.ndarray,
         mixture: np.ndarray,
@@ -466,8 +466,7 @@ def LogWMSE_metric(
     mixture = torch.from_numpy(mixture).unsqueeze(0).to(device)
 
     res = log_wmse(mixture, reference, estimate)
-
-    return float(res.cpu().numpy())
+    return -float(res.cpu().numpy())
 
 
 def AuraSTFT_metric(
@@ -705,8 +704,8 @@ def get_metrics(
     if 'l1_freq' in metrics:
         result['l1_freq'] = L1Freq_metric(reference, estimate, device=device)
 
-    if 'log_wmse' in metrics:
-        result['log_wmse'] = LogWMSE_metric(reference, estimate, mix, device)
+    if 'neg_log_wmse' in metrics:
+        result['neg_log_wmse'] = NegLogWMSE_metric(reference, estimate, mix, device)
 
     if 'aura_stft' in metrics:
         result['aura_stft'] = AuraSTFT_metric(reference, estimate, device)

--- a/valid.py
+++ b/valid.py
@@ -635,6 +635,10 @@ def run_parallel_validation(
         A shared dictionary containing the validation metrics from all processes.
     """
 
+
+    if verbose:
+        print(f'Total mixtures: {len(all_mixtures_path)}')
+        print(f'Overlap: {config.inference.num_overlap} Batch size: {config.inference.batch_size}')
     model = model.to('cpu')
     try:
         # For multiGPU training extract single model
@@ -710,7 +714,8 @@ def valid_multi_gpu(
     all_mixtures_path = get_mixture_paths(args, verbose, config, extension)
 
     return_dict = torch.multiprocessing.Manager().dict()
-    run_parallel_validation(verbose, all_mixtures_path, config, model, device_ids, args, return_dict)
+
+    return_dict = run_parallel_validation(verbose, all_mixtures_path, config, model, device_ids, args, return_dict)
 
     all_metrics = dict()
     for metric in args.metrics:
@@ -737,7 +742,7 @@ def check_validation(args):
     parser.add_argument("--pin_memory", type=bool, default=False, help="dataloader pin_memory")
     parser.add_argument("--extension", type=str, default='wav', help="Choose extension for validation")
     parser.add_argument("--use_tta", action='store_true', help="Flag adds test time augmentation during inference (polarity and channel inverse). While this triples the runtime, it reduces noise and slightly improves prediction quality.")
-    parser.add_argument("--metrics", nargs='+', type=str, default=["sdr"], choices=['sdr', 'l1_freq', 'si_sdr', 'log_wmse', 'aura_stft', 'aura_mrstft', 'bleedless', 'fullness'], help='List of metrics to use.')
+    parser.add_argument("--metrics", nargs='+', type=str, default=["sdr"], choices=['sdr', 'l1_freq', 'si_sdr', 'neg_log_wmse', 'aura_stft', 'aura_mrstft', 'bleedless', 'fullness'], help='List of metrics to use.')
     if args is None:
         args = parser.parse_args()
     else:

--- a/valid.py
+++ b/valid.py
@@ -635,10 +635,6 @@ def run_parallel_validation(
         A shared dictionary containing the validation metrics from all processes.
     """
 
-
-    if verbose:
-        print(f'Total mixtures: {len(all_mixtures_path)}')
-        print(f'Overlap: {config.inference.num_overlap} Batch size: {config.inference.batch_size}')
     model = model.to('cpu')
     try:
         # For multiGPU training extract single model
@@ -715,7 +711,7 @@ def valid_multi_gpu(
 
     return_dict = torch.multiprocessing.Manager().dict()
 
-    return_dict = run_parallel_validation(verbose, all_mixtures_path, config, model, device_ids, args, return_dict)
+    run_parallel_validation(verbose, all_mixtures_path, config, model, device_ids, args, return_dict)
 
     all_metrics = dict()
     for metric in args.metrics:


### PR DESCRIPTION
Changes in the code:

1. Changed the `utilts.py` file:
   - The metric `log_wmse` has been replaced with `neg_log_wmse`.

2. Changed the `valid.py` file:
   - The metric `log_wmse` has been replaced with `neg_log_wmse` in the `args` instructions.

3. Changed the `train.py` file:
   - Key change: the loss function is now set before training begins. The `multi_loss` function works differently based on `args`. Previously, the loss function was selected at each step depending on `args`, but now the selection occurs once during initialization.
   - The code has been refactored into functions:
     - `parse_args`: for reading arguments.
     - `manual_seed`: for setting random values.
     - `initialize_environment`: for preparing the environment.
     - `wandb_init`: for initializing wandb.
     - `prepare_data`: for preparing the data.
     - `load_start_checkpoint`: for loading the initial checkpoint.
     - `get_optimizer`: for setting up the optimizer.
     - `multistft_loss`: for calculating STFT losses.
     - `choice_loss`: for selecting the loss function.
     - `normalize_batch`: for normalizing the data.
     - `train_one_epoch`: for training for one epoch.
     - `save_weights` and `save_last_weights`: for saving weights.
     - `compute_epoch_metrics`: for computing metrics after each epoch.
   - Logic:
     - Arguments are read using `parse_args`.
     - Environment is initialized and data is prepared via `manual_seed`, `initialize_environment`, `wandb_init`, `load_start_checkpoint`.
     - The optimizer is set up using `get_optimizer` and the loss function is chosen using `choice_loss`, which returns the `multi_loss` function used for calculating the loss.
     - A loop runs over epochs, calling `train_one_epoch`, saving the latest weights with `save_last_weights`, and computing metrics via `compute_epoch_metrics`.
   - Type hints and docstrings have been added to all functions.

4. Changes have been tested on `train.py`:
   - With one GPU using various loss metrics.
   - Using `masked_loss` on multiple GPUs.





