### PR TITLE
A tiny fix for the click issue at chunk edges when using batch_size=1

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -391,7 +391,7 @@ def demix(
                     x = model(arr)
 
                     if mode == "generic":
-                        window = windowing_array
+                        window = windowing_array.clone() # using clone() fixes the clicks at chunk edges when using batch_size=1
                         if i - step == 0:  # First audio chunk, no fadein
                             window[:fade_size] = 1
                         elif i >= mix.shape[1]:  # Last audio chunk, no fadeout


### PR DESCRIPTION

Before the fix with batch_size=1 (clicks are obvious at bottom of spectrograms)
![24560889-31f6-4dd8-9a96-3b9909da5d7e](https://github.com/user-attachments/assets/6545c73f-599c-4f5d-a734-e71aa85bc593)


After the fix:
![be2ab7b5-d1fd-4fca-aeaa-328fe7b6a891](https://github.com/user-attachments/assets/8e00e2af-6edf-42d8-9c6d-f22576c17636)
