### PR TITLE
Changed args processing

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -144,10 +144,13 @@ def parse_args(dict_args: Union[Dict, None]) -> argparse.Namespace:
                         "While this triples the runtime, it reduces noise and slightly improves prediction quality.")
     parser.add_argument("--lora_checkpoint", type=str, default='', help="Initial checkpoint to LoRA weights")
 
-    if dict_args is None:
-        args = parser.parse_args()
+    if dict_args is not None:
+        args = parser.parse_args([])
+        args_dict = vars(args)
+        args_dict.update(dict_args)
+        args = argparse.Namespace(**args_dict)
     else:
-        args = argparse.Namespace(**dict_args)
+        args = parser.parse_args()
 
     return args
 

--- a/inference.py
+++ b/inference.py
@@ -11,15 +11,17 @@ import torch
 import soundfile as sf
 from tqdm.auto import tqdm
 import torch.nn as nn
+from typing import Dict, Union
 
 # Using the embedded version of Python can also correctly import the utils module.
 current_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(current_dir)
 
 from utils import demix, get_model_from_config, normalize_audio, denormalize_audio, draw_spectrogram
-from utils import prefer_target_instrument, apply_tta, load_start_checkpoint, load_lora_weights
+from utils import prefer_target_instrument, apply_tta, load_start_checkpoint
 
 import warnings
+
 warnings.filterwarnings("ignore")
 
 
@@ -108,33 +110,56 @@ def run_folder(model, args, config, device, verbose: bool = False):
     print(f"Elapsed time: {time.time() - start_time:.2f} seconds.")
 
 
-def proc_folder(args):
+def parse_args(dict_args: Union[Dict, None]) -> argparse.Namespace:
+    """
+    Parse command-line arguments for configuring the model, dataset, and training parameters.
+
+    Args:
+        dict_args: Dict of command-line arguments. If None, arguments will be parsed from sys.argv.
+
+    Returns:
+        Namespace object containing parsed arguments and their values.
+    """
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model_type", type=str, default='mdx23c', help="One of bandit, bandit_v2, bs_roformer, htdemucs, mdx23c, mel_band_roformer, scnet, scnet_unofficial, segm_models, swin_upernet, torchseg")
+    parser.add_argument("--model_type", type=str, default='mdx23c',
+                        help="One of bandit, bandit_v2, bs_roformer, htdemucs, mdx23c, mel_band_roformer,"
+                             " scnet, scnet_unofficial, segm_models, swin_upernet, torchseg")
     parser.add_argument("--config_path", type=str, help="path to config file")
     parser.add_argument("--start_check_point", type=str, default='', help="Initial checkpoint to valid weights")
     parser.add_argument("--input_folder", type=str, help="folder with mixtures to process")
     parser.add_argument("--store_dir", type=str, default="", help="path to store results as wav file")
-    parser.add_argument("--draw_spectro", type=float, default=0, help="Code will generate spectrograms for resulted stems. Value defines for how many seconds os track spectrogram will be generated.")
+    parser.add_argument("--draw_spectro", type=float, default=0,
+                        help="Code will generate spectrograms for resulted stems."
+                             " Value defines for how many seconds os track spectrogram will be generated.")
     parser.add_argument("--device_ids", nargs='+', type=int, default=0, help='list of gpu ids')
-    parser.add_argument("--extract_instrumental", action='store_true', help="invert vocals to get instrumental if provided")
+    parser.add_argument("--extract_instrumental", action='store_true',
+                        help="invert vocals to get instrumental if provided")
     parser.add_argument("--disable_detailed_pbar", action='store_true', help="disable detailed progress bar")
     parser.add_argument("--force_cpu", action='store_true', help="Force the use of CPU even if CUDA is available")
     parser.add_argument("--flac_file", action='store_true', help="Output flac file instead of wav")
-    parser.add_argument("--pcm_type", type=str, choices=['PCM_16', 'PCM_24'], default='PCM_24', help="PCM type for FLAC files (PCM_16 or PCM_24)")
-    parser.add_argument("--use_tta", action='store_true', help="Flag adds test time augmentation during inference (polarity and channel inverse). While this triples the runtime, it reduces noise and slightly improves prediction quality.")
+    parser.add_argument("--pcm_type", type=str, choices=['PCM_16', 'PCM_24'], default='PCM_24',
+                        help="PCM type for FLAC files (PCM_16 or PCM_24)")
+    parser.add_argument("--use_tta", action='store_true',
+                        help="Flag adds test time augmentation during inference (polarity and channel inverse)."
+                        "While this triples the runtime, it reduces noise and slightly improves prediction quality.")
     parser.add_argument("--lora_checkpoint", type=str, default='', help="Initial checkpoint to LoRA weights")
-    if args is None:
+
+    if dict_args is None:
         args = parser.parse_args()
     else:
-        args = parser.parse_args(args)
+        args = argparse.Namespace(**dict_args)
 
+    return args
+
+
+def proc_folder(dict_args):
+    args = parse_args(dict_args)
     device = "cpu"
     if args.force_cpu:
         device = "cpu"
     elif torch.cuda.is_available():
         print('CUDA is available, use --force_cpu to disable it.')
-        device = f'cuda:{args.device_ids[0]}' if type(args.device_ids) == list else f'cuda:{args.device_ids}'
+        device = f'cuda:{args.device_ids[0]}' if isinstance(args.device_ids, list) else f'cuda:{args.device_ids}'
     elif torch.backends.mps.is_available():
         device = "mps"
 
@@ -151,8 +176,8 @@ def proc_folder(args):
     print("Instruments: {}".format(config.training.instruments))
 
     # in case multiple CUDA GPUs are used and --device_ids arg is passed
-    if type(args.device_ids) == list and len(args.device_ids) > 1 and not args.force_cpu:
-        model = nn.DataParallel(model, device_ids = args.device_ids)
+    if isinstance(args.device_ids, list) and len(args.device_ids) > 1 and not args.force_cpu:
+        model = nn.DataParallel(model, device_ids=args.device_ids)
 
     model = model.to(device)
 

--- a/models/bs_roformer/bs_roformer.py
+++ b/models/bs_roformer/bs_roformer.py
@@ -485,8 +485,9 @@ class BSRoformer(Module):
         try:
             stft_repr = torch.stft(raw_audio, **self.stft_kwargs, window=stft_window, return_complex=True)
         except:
-            stft_repr = torch.stft(raw_audio.cpu() if x_is_mps else raw_audio, **self.stft_kwargs, window=stft_window.cpu() if x_is_mps else stft_window, return_complex=True).to(device)
-
+            stft_repr = torch.stft(raw_audio.cpu() if x_is_mps else raw_audio, **self.stft_kwargs,
+                                   window=stft_window.cpu() if x_is_mps else stft_window, return_complex=True).to(
+                device)
         stft_repr = torch.view_as_real(stft_repr)
 
         stft_repr = unpack_one(stft_repr, batch_audio_channel_packed_shape, '* f t c')

--- a/scripts/moises_to_musdb.py
+++ b/scripts/moises_to_musdb.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 import shutil
 import time
 from multiprocessing import Pool
-from typing import List, Tuple, Dict, Optional
+from typing import List, Tuple, Dict, Optional, Union
 import argparse
 
 
@@ -197,19 +197,15 @@ def count_folders_parallel(src_folder: str, stems, num_workers: int = 4) -> Dict
     return merged_counts
 
 
-def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
+def parse_args(dict_args: Union[Dict, None]) -> argparse.Namespace:
     """
-    Parse command-line arguments.
+    Parse command-line arguments for configuring the model, dataset, and training parameters.
 
-    Parameters:
-    ----------
-    args : Optional[List[str]]
-        List of arguments passed from the command line. If None, uses sys.argv.
+    Args:
+        dict_args: Dict of command-line arguments. If None, arguments will be parsed from sys.argv.
 
     Returns:
-    -------
-    argparse.Namespace
-        The parsed arguments containing valid_dir, inference_dir, and mixture_name.
+        Namespace object containing parsed arguments and their values.
     """
     parser = argparse.ArgumentParser(description="Copy mixture files from VALID_DIR to INFERENCE_DIR")
     parser.add_argument('--src_dir', type=str, required=True, help="Source directory with MoisesDB tracks")
@@ -224,10 +220,11 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
                                  'bowed_strings', 'wind', 'other_plucked'], help='List of stems to use.')
     parser.add_argument('--mixture_name', type=str, default='mixture.wav', help="Name of mixture tracks")
 
-    if args is None:
+    if dict_args is None:
         args = parser.parse_args()
     else:
-        args = parser.parse_args(args)
+        args = argparse.Namespace(**dict_args)
+
     return args
 
 
@@ -289,6 +286,7 @@ def main(args: Optional[argparse.Namespace] = None) -> None:
                 print(f"Folder {source_folder} not found.")
 
     print('The end!')
+
 
 if __name__ == '__main__':
     main(None)

--- a/scripts/moises_to_musdb.py
+++ b/scripts/moises_to_musdb.py
@@ -220,10 +220,13 @@ def parse_args(dict_args: Union[Dict, None]) -> argparse.Namespace:
                                  'bowed_strings', 'wind', 'other_plucked'], help='List of stems to use.')
     parser.add_argument('--mixture_name', type=str, default='mixture.wav', help="Name of mixture tracks")
 
-    if dict_args is None:
-        args = parser.parse_args()
+    if dict_args is not None:
+        args = parser.parse_args([])
+        args_dict = vars(args)
+        args_dict.update(dict_args)
+        args = argparse.Namespace(**args_dict)
     else:
-        args = argparse.Namespace(**dict_args)
+        args = parser.parse_args()
 
     return args
 

--- a/scripts/redact_config.py
+++ b/scripts/redact_config.py
@@ -87,10 +87,13 @@ def parse_args(dict_args: Union[Dict, None]) -> argparse.Namespace:
     parser.add_argument("--model_type", type=str, default="", help="Model type")
     parser.add_argument("--new_config", type=str, default="", help="Path to save the new test configuration file.")
 
-    if dict_args is None:
-        args = parser.parse_args()
+    if dict_args is not None:
+        args = parser.parse_args([])
+        args_dict = vars(args)
+        args_dict.update(dict_args)
+        args = argparse.Namespace(**args_dict)
     else:
-        args = argparse.Namespace(**dict_args)
+        args = parser.parse_args()
 
     # Determine the default path for the new configuration if not provided
     if not args.new_config:

--- a/scripts/redact_config.py
+++ b/scripts/redact_config.py
@@ -3,7 +3,7 @@ import os
 import sys
 import argparse
 from omegaconf import OmegaConf
-from typing import Union, List
+from typing import Union, List, Dict
 from ml_collections import ConfigDict
 
 
@@ -33,9 +33,11 @@ def save_config(config: Union[ConfigDict, OmegaConf], save_path: str):
             elif isinstance(config, OmegaConf):
                 OmegaConf.save(config, save_path)
             else:
-                raise ValueError("Unsupported configuration type. Supported types: ConfigDict, OmegaConf.")
+                OmegaConf.save(config, save_path)
     except Exception as e:
-        raise ValueError(f"Error saving configuration: {e}")
+        raise ValueError(f"Error saving configuration: {e}."
+                         f"Unsupported configuration type. Supported types: ConfigDict, OmegaConf."
+                         f"Config type is {type(config)}")
 
 
 def create_test_config(original_config_path: str, new_config_path: str, model_type: str):
@@ -69,12 +71,12 @@ def create_test_config(original_config_path: str, new_config_path: str, model_ty
     print(f"Test config created at: {new_config_path}")
 
 
-def parse_args(args: Union[List[str], None]) -> argparse.Namespace:
+def parse_args(dict_args: Union[Dict, None]) -> argparse.Namespace:
     """
     Parse command-line arguments for configuring the model, dataset, and training parameters.
 
     Args:
-        args: List of command-line arguments. If None, arguments will be parsed from sys.argv.
+        dict_args: Dict of command-line arguments. If None, arguments will be parsed from sys.argv.
 
     Returns:
         Namespace object containing parsed arguments and their values.
@@ -85,15 +87,15 @@ def parse_args(args: Union[List[str], None]) -> argparse.Namespace:
     parser.add_argument("--model_type", type=str, default="", help="Model type")
     parser.add_argument("--new_config", type=str, default="", help="Path to save the new test configuration file.")
 
-    if args is None:
+    if dict_args is None:
         args = parser.parse_args()
     else:
-        args = parser.parse_args(args)
+        args = argparse.Namespace(**dict_args)
 
     # Determine the default path for the new configuration if not provided
     if not args.new_config:
         original_dir = os.path.dirname(args.orig_config)
-        tests_dir = os.path.join("tests", original_dir)
+        tests_dir = os.path.join("tests_cache", original_dir)
         os.makedirs(tests_dir, exist_ok=True)
         args.new_config = os.path.join(tests_dir, os.path.basename(args.orig_config))
 
@@ -112,8 +114,4 @@ def redact_config(args):
 
 
 if __name__ == '__main__':
-    args = [
-        '--orig_config', 'configs/config_musdb18_scnet_large_starrytong.yaml',
-        '--model_type', 'scnet'
-    ]
     redact_config(None)

--- a/scripts/trim.py
+++ b/scripts/trim.py
@@ -1,21 +1,24 @@
 import os
+from sys import argv
+
 import soundfile as sf
 import argparse
 import time
-from typing import Union, List
+from typing import Union, List, Dict
 
 
-def parse_args(args: Union[List[str], None]) -> argparse.Namespace:
+def parse_args(dict_args: Union[Dict, None]) -> argparse.Namespace:
     """
     Parse command-line arguments for configuring the model, dataset, and training parameters.
 
     Args:
-        args: List of command-line arguments. If None, arguments will be parsed from sys.argv.
+        dict_args: Dict of command-line arguments. If None, arguments will be parsed from sys.argv.
 
     Returns:
         Namespace object containing parsed arguments and their values.
     """
-    parser = argparse.ArgumentParser(description="Trim audio files in a directory and its subdirectories.")
+
+    parser = argparse.ArgumentParser()
     parser.add_argument('--input_directory', type=str, help="Path to the input directory.")
     parser.add_argument('--output_directory', type=str, help="Path to the output directory.")
     parser.add_argument('--start_sec', type=float, default=20.0)
@@ -23,10 +26,13 @@ def parse_args(args: Union[List[str], None]) -> argparse.Namespace:
     parser.add_argument('--codec', type=str, default='wav')
     parser.add_argument('--max_folders', type=int, default=float('inf'), help="Maximum number of folders to process.")
 
-    if args is None:
-        args = parser.parse_args()
+    if dict_args is not None:
+        args = parser.parse_args([])
+        args_dict = vars(args)
+        args_dict.update(dict_args)
+        args = argparse.Namespace(**args_dict)
     else:
-        args = parser.parse_args(args)
+        args = parser.parse_args()
 
     if not args.output_directory:
         original_dir = os.path.dirname(args.input_directory)
@@ -46,9 +52,7 @@ def trim_wav(input_file: str, output_file: str, start_sec: float, end_sec: float
 
 
 def trim_directory(args):
-
     args = parse_args(args)
-
     input_directory = args.input_directory
     output_directory = args.output_directory
     start_sec = args.start_sec

--- a/scripts/valid_to_inference.py
+++ b/scripts/valid_to_inference.py
@@ -1,32 +1,31 @@
 import os
 import shutil
 import argparse
-from typing import List, Optional
+from typing import List, Optional, Union, Dict
 
-def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
+
+def parse_args(dict_args: Union[Dict, None]) -> argparse.Namespace:
     """
-    Parse command-line arguments.
+    Parse command-line arguments for configuring the model, dataset, and training parameters.
 
-    Parameters:
-    ----------
-    args : Optional[List[str]]
-        List of arguments passed from the command line. If None, uses sys.argv.
+    Args:
+        dict_args: Dict of command-line arguments. If None, arguments will be parsed from sys.argv.
 
     Returns:
-    -------
-    argparse.Namespace
-        The parsed arguments containing valid_path, inference_dir, and mixture_name.
+        Namespace object containing parsed arguments and their values.
     """
+
     parser = argparse.ArgumentParser(description="Copy mixture files from VALID_PATH to INFERENCE_DIR")
     parser.add_argument('--valid_path', type=str, required=True, help="Directory with valid tracks")
     parser.add_argument('--inference_dir', type=str, required=True, help="Directory to save inference tracks")
     parser.add_argument('--mixture_name', type=str, default='mixture.wav', help="Name of mixture tracks (default: 'mixture.wav')")
     parser.add_argument('--max_mixtures', type=int, default=float('inf'), help="Maximum number of mixtures to process.")
 
-    if args is None:
+    if dict_args is None:
         args = parser.parse_args()
     else:
-        args = parser.parse_args(args)
+        args = argparse.Namespace(**dict_args)
+
     return args
 
 

--- a/scripts/valid_to_inference.py
+++ b/scripts/valid_to_inference.py
@@ -16,15 +16,18 @@ def parse_args(dict_args: Union[Dict, None]) -> argparse.Namespace:
     """
 
     parser = argparse.ArgumentParser(description="Copy mixture files from VALID_PATH to INFERENCE_DIR")
-    parser.add_argument('--valid_path', type=str, required=True, help="Directory with valid tracks")
-    parser.add_argument('--inference_dir', type=str, required=True, help="Directory to save inference tracks")
+    parser.add_argument('--valid_path', type=str, help="Directory with valid tracks")
+    parser.add_argument('--inference_dir', type=str, help="Directory to save inference tracks")
     parser.add_argument('--mixture_name', type=str, default='mixture.wav', help="Name of mixture tracks (default: 'mixture.wav')")
     parser.add_argument('--max_mixtures', type=int, default=float('inf'), help="Maximum number of mixtures to process.")
 
-    if dict_args is None:
-        args = parser.parse_args()
+    if dict_args is not None:
+        args = parser.parse_args([])
+        args_dict = vars(args)
+        args_dict.update(dict_args)
+        args = argparse.Namespace(**args_dict)
     else:
-        args = argparse.Namespace(**dict_args)
+        args = parser.parse_args()
 
     return args
 

--- a/tests/admin_test.py
+++ b/tests/admin_test.py
@@ -1,0 +1,177 @@
+import shutil
+from test import test_settings
+from scripts.redact_config import redact_config
+from utils import load_config
+from pathlib import Path
+import os
+import numpy as np
+import soundfile as sf
+from typing import List, Dict
+
+MODEL_CONFIGS = {
+    'config_apollo.yaml': {'model_type': 'apollo'},
+    'config_dnr_bandit_bsrnn_multi_mus64.yaml': {'model_type': 'bandit'},
+    'config_dnr_bandit_v2_mus64.yaml': {'model_type': 'bandit_v2'},
+    'config_drumsep.yaml': {'model_type': 'htdemucs'},
+    'config_htdemucs_6stems.yaml': {'model_type': 'htdemucs'},
+    'config_musdb18_bs_roformer.yaml': {'model_type': 'bs_roformer'},
+    'config_musdb18_demucs3_mmi.yaml': {'model_type': 'htdemucs'},
+    'config_musdb18_htdemucs.yaml': {'model_type': 'htdemucs'},
+    'config_musdb18_mdx23c.yaml': {'model_type': 'mdx23c'},
+    'config_musdb18_mel_band_roformer.yaml': {'model_type': 'mel_band_roformer'},
+    'config_musdb18_mel_band_roformer_all_stems.yaml': {'model_type': 'mel_band_roformer'},
+    'config_musdb18_scnet.yaml': {'model_type': 'scnet'},
+    'config_musdb18_scnet_large.yaml': {'model_type': 'scnet'},
+    'config_musdb18_scnet_large_starrytong.yaml': {'model_type': 'scnet'},
+    'config_vocals_bandit_bsrnn_multi_mus64.yaml': {'model_type': 'bandit'},
+    'config_vocals_bs_roformer.yaml': {'model_type': 'bs_roformer'},
+    'config_vocals_htdemucs.yaml': {'model_type': 'htdemucs'},
+    'config_vocals_mdx23c.yaml': {'model_type': 'mdx23c'},
+    'config_vocals_mel_band_roformer.yaml': {'model_type': 'mel_band_roformer'},
+    'config_vocals_scnet.yaml': {'model_type': 'scnet'},
+    'config_vocals_scnet_large.yaml': {'model_type': 'scnet'},
+    'config_vocals_scnet_unofficial.yaml': {'model_type': 'scnet_unofficial'},
+    'config_vocals_segm_models.yaml': {'model_type': 'segm_models'},
+
+
+    # 'config_vocals_swin_upernet.yaml': {'model_type': 'swin_upernet'},
+    # 'config_musdb18_torchseg.yaml': {'model_type': 'torchseg'},
+    # 'config_musdb18_segm_models.yaml': {'model_type': 'segm_models'},
+    # 'config_musdb18_bs_mamba2.yaml': {'model_type': 'bs_mamba2'},
+    # 'config_vocals_bs_mamba2.yaml': {'model_type': 'bs_mamba2'},
+    # 'config_vocals_torchseg.yaml': {'model_type': 'torchseg'}
+}
+
+
+# Директории для тестов
+TEST_DIR = Path("tests_cache")
+TRAIN_DIR = TEST_DIR / "train_tracks"
+VALID_DIR = TEST_DIR / "valid_tracks"
+
+
+def create_dummy_tracks(directory: Path, num_tracks: int, instruments: List[str],
+                        duration: float = 5.0, sample_rate: int = 44100) -> None:
+    """
+    Generates random audio tracks for stems in two subdirectories within the specified directory.
+
+    Parameters:
+    ----------
+    directory : Path
+        Path to the directory where the tracks will be saved.
+    num_tracks : int
+        Number of tracks to generate in each folder.
+    instruments : List[str]
+        List of instrument names (stems) to create.
+    duration : float, optional
+        Duration of each track in seconds. Default is 5.0.
+    sample_rate : int, optional
+        Sampling rate of the generated audio. Default is 44100 Hz.
+
+    Returns:
+    -------
+    None
+    """
+
+    os.makedirs(directory, exist_ok=True)
+
+    for folder_name in [str(i) for i in range(1, num_tracks+1)]:
+        folder_path = directory / folder_name
+        os.makedirs(folder_path, exist_ok=True)
+        for instrument in instruments:
+            # Generate random noice for each track
+            samples = int(duration * sample_rate)
+            track = np.random.uniform(-1.0, 1.0, (2, samples)).astype(np.float32)
+            file_path = folder_path / f"{instrument}.wav"
+            sf.write(file_path, track.T, sample_rate)
+
+
+def cleanup_test_tracks() -> None:
+    """
+    Removes all cached test tracks.
+
+    This function deletes the entire directory specified by the global `TEST_DIR` variable
+    if it exists.
+
+    Returns:
+    -------
+    None
+        This function does not return a value. It performs cleanup of test data.
+    """
+
+
+def modify_configs() -> Dict[str, Path]:
+    """
+    Updates configuration files in the `configs` directory for use with test data.
+
+    This function processes configuration files defined in the global `MODEL_CONFIGS` dictionary,
+    modifies them to be compatible with test scenarios, and saves the updated configurations
+    in a test-specific directory.
+
+    Returns:
+    -------
+    Dict[str, Path]
+        A dictionary where the keys are the original configuration file names, and the values
+        are the paths to the updated configuration files.
+    """
+    config_dir = Path("configs")
+    updated_configs = {}
+    for config, args in MODEL_CONFIGS.items():
+        model_type = args['model_type']
+        config_path = config_dir / config
+        updated_config_path = redact_config({
+            'orig_config': str(config_path),
+            'model_type': model_type,
+            'new_config': str(TEST_DIR / 'configs' / config)
+        })
+        updated_configs[config] = updated_config_path
+    return updated_configs
+
+
+def run_tests() -> None:
+    """
+    Executes validation tests for all configurations.
+
+    This function updates configurations, generates random dummy data for testing,
+    and runs a series of tests (training, validation, and inference checks) for each
+    model configuration specified in the global `MODEL_CONFIGS` dictionary.
+
+    Returns:
+    -------
+    None
+    """
+
+    updated_configs = modify_configs()
+
+    # For every config
+    for config, args in MODEL_CONFIGS.items():
+        model_type = args['model_type']
+        cfg = load_config(model_type=model_type, config_path=TEST_DIR / 'configs' / config)
+        # Random tracks
+        create_dummy_tracks(TRAIN_DIR, instruments=cfg.training.instruments+['mixture'], num_tracks=2)
+        create_dummy_tracks(VALID_DIR, instruments=cfg.training.instruments+['mixture'], num_tracks=2)
+
+        print(f"\nRunning tests for model: {model_type} (config: {config})")
+
+        test_args = {
+            'check_train': False,
+            'check_valid': True,
+            'check_inference': True,
+            'config_path': updated_configs[config],
+            'data_path': str(TRAIN_DIR),
+            'valid_path': str(VALID_DIR),
+            'results_path': str(TEST_DIR / "results" / model_type),
+            'store_dir': str(TEST_DIR / "inference_results" / model_type),
+            'metrics': ['sdr', 'si_sdr', 'l1_freq']
+        }
+
+        test_args.update(args)
+
+        test_settings(test_args, 'admin')
+        print(f"Tests for model {model_type} completed successfully.")
+
+    # Remove test_cache
+    cleanup_test_tracks()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/test.py
+++ b/tests/test.py
@@ -23,7 +23,7 @@ base_args = {
     'store_dir': 'tests/valid_inference_result',
     'input_folder': '',
     'metrics': ['neg_log_wmse', 'l1_freq', 'si_sdr', 'sdr', 'aura_stft', 'aura_mrstft', 'bleedless', 'fullness'],
-    'max_folders': '2'
+    'max_folders': 2
 }
 
 
@@ -74,16 +74,19 @@ def parse_args(dict_args):
                         help="If --store_dir is set then code will generate spectrograms for resulted stems as well."
                              " Value defines for how many seconds os track spectrogram will be generated.")
 
-    args = parser.parse_args()
-
     if dict_args is not None:
-        for key, value in dict_args.items():
-            setattr(args, key, value)
+        args = parser.parse_args([])
+        args_dict = vars(args)
+        args_dict.update(dict_args)
+        args = argparse.Namespace(**args_dict)
+    else:
+        args = parser.parse_args()
 
     return args
 
 
 def test_settings(dict_args, test_type):
+
     # Parse from cmd
     cli_args = parse_args(dict_args)
 
@@ -104,22 +107,24 @@ def test_settings(dict_args, test_type):
 
         # Replace config
         base_args['config_path'] = redact_config({'orig_config': base_args['config_path'],
-                                                  'model_type': base_args['model_type']})
+                                                  'model_type': base_args['model_type'],
+                                                  'new_config': ''})
+
         # Trim train
-        trim_args_train = ['--input_directory', base_args['data_path'],
-                           '--max_folders', base_args['max_folders']]
+        trim_args_train = {'input_directory': base_args['data_path'],
+                           'max_folders': base_args['max_folders']}
         base_args['data_path'] = trim_directory(trim_args_train)
         # Trim valid
-        trim_args_valid = ['--input_directory', base_args['valid_path'],
-                           '--max_folders', base_args['max_folders']]
+        trim_args_valid = {'input_directory': base_args['valid_path'],
+                           'max_folders': base_args['max_folders']}
         base_args['valid_path'] = trim_directory(trim_args_valid)
     # Valid to inference
     if not base_args['input_folder']:
         tests_dir = os.path.join(os.path.dirname(base_args['valid_path']), 'for_inference')
         base_args['input_folder'] = tests_dir
-    val_to_inf_args = ['--valid_path', base_args['valid_path'],
-                       '--inference_dir', base_args['input_folder'],
-                       '--max_mixtures', '1']
+    val_to_inf_args = {'valid_path': base_args['valid_path'],
+                       'inference_dir': base_args['input_folder'],
+                       'max_mixtures': 1}
     copying_files(val_to_inf_args)
 
     if base_args['check_valid']:

--- a/train.py
+++ b/train.py
@@ -71,10 +71,13 @@ def parse_args(dict_args: Union[Dict, None]) -> argparse.Namespace:
     parser.add_argument("--train_lora", action='store_true', help="Train with LoRA")
     parser.add_argument("--lora_checkpoint", type=str, default='', help="Initial checkpoint to LoRA weights")
 
-    if dict_args is None:
-        args = parser.parse_args()
+    if dict_args is not None:
+        args = parser.parse_args([])
+        args_dict = vars(args)
+        args_dict.update(dict_args)
+        args = argparse.Namespace(**args_dict)
     else:
-        args = argparse.Namespace(**dict_args)
+        args = parser.parse_args()
 
     if args.metric_for_scheduler not in args.metrics:
         args.metrics += [args.metric_for_scheduler]

--- a/train.py
+++ b/train.py
@@ -31,12 +31,12 @@ import warnings
 warnings.filterwarnings("ignore")
 
 
-def parse_args(args: Union[List[str], None]) -> argparse.Namespace:
+def parse_args(dict_args: Union[Dict, None]) -> argparse.Namespace:
     """
     Parse command-line arguments for configuring the model, dataset, and training parameters.
 
     Args:
-        args: List of command-line arguments. If None, arguments will be parsed from sys.argv.
+        dict_args: Dict of command-line arguments. If None, arguments will be parsed from sys.argv.
 
     Returns:
         Namespace object containing parsed arguments and their values.
@@ -71,10 +71,10 @@ def parse_args(args: Union[List[str], None]) -> argparse.Namespace:
     parser.add_argument("--train_lora", action='store_true', help="Train with LoRA")
     parser.add_argument("--lora_checkpoint", type=str, default='', help="Initial checkpoint to LoRA weights")
 
-    if args is None:
+    if dict_args is None:
         args = parser.parse_args()
     else:
-        args = parser.parse_args(args)
+        args = argparse.Namespace(**dict_args)
 
     if args.metric_for_scheduler not in args.metrics:
         args.metrics += [args.metric_for_scheduler]
@@ -187,7 +187,7 @@ def initialize_model_and_device(model: torch.nn.Module, device_ids: List[int]) -
             model = nn.DataParallel(model, device_ids=device_ids).to(device)
     else:
         device = 'cpu'
-        model = device, model.to(device)
+        model = model.to(device)
         print("CUDA is not available. Running on CPU.")
 
     return device, model
@@ -560,7 +560,7 @@ def train_model(args: argparse.Namespace) -> None:
     for epoch in range(config.training.num_epochs):
 
         train_one_epoch(model, config, args, optimizer, device, device_ids, epoch,
-                         use_amp, scaler, gradient_accumulation_steps, train_loader, multi_loss)
+                        use_amp, scaler, gradient_accumulation_steps, train_loader, multi_loss)
         save_last_weights(args, model, device_ids)
         best_metric = compute_epoch_metrics(model, args, config, device, device_ids, best_metric, epoch, scheduler)
 

--- a/valid.py
+++ b/valid.py
@@ -631,10 +631,13 @@ def parse_args(dict_args: Union[Dict, None]) -> argparse.Namespace:
                                  'fullness'], help='List of metrics to use.')
     parser.add_argument("--lora_checkpoint", type=str, default='', help="Initial checkpoint to LoRA weights")
 
-    if dict_args is None:
-        args = parser.parse_args()
+    if dict_args is not None:
+        args = parser.parse_args([])
+        args_dict = vars(args)
+        args_dict.update(dict_args)
+        args = argparse.Namespace(**args_dict)
     else:
-        args = argparse.Namespace(**dict_args)
+        args = parser.parse_args()
 
     return args
 

--- a/valid.py
+++ b/valid.py
@@ -597,27 +597,50 @@ def valid_multi_gpu(
     return compute_metric_avg(store_dir, args, instruments, config, all_metrics, start_time)
 
 
-def check_validation(args):
+def parse_args(dict_args: Union[Dict, None]) -> argparse.Namespace:
+    """
+    Parse command-line arguments for configuring the model, dataset, and training parameters.
+
+    Args:
+        dict_args: Dict of command-line arguments. If None, arguments will be parsed from sys.argv.
+
+    Returns:
+        Namespace object containing parsed arguments and their values.
+    """
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model_type", type=str, default='mdx23c', help="One of mdx23c, htdemucs, segm_models, mel_band_roformer, bs_roformer, swin_upernet, bandit")
+    parser.add_argument("--model_type", type=str, default='mdx23c',
+                        help="One of mdx23c, htdemucs, segm_models, mel_band_roformer,"
+                             " bs_roformer, swin_upernet, bandit")
     parser.add_argument("--config_path", type=str, help="Path to config file")
-    parser.add_argument("--start_check_point", type=str, default='', help="Initial checkpoint to valid weights")
+    parser.add_argument("--start_check_point", type=str, default='', help="Initial checkpoint"
+                                                                          " to valid weights")
     parser.add_argument("--valid_path", nargs="+", type=str, help="Validate path")
     parser.add_argument("--store_dir", type=str, default="", help="Path to store results as wav file")
-    parser.add_argument("--draw_spectro", type=float, default=0, help="If --store_dir is set then code will generate spectrograms for resulted stems as well. Value defines for how many seconds os track spectrogram will be generated.")
+    parser.add_argument("--draw_spectro", type=float, default=0,
+                        help="If --store_dir is set then code will generate spectrograms for resulted stems as well."
+                             " Value defines for how many seconds os track spectrogram will be generated.")
     parser.add_argument("--device_ids", nargs='+', type=int, default=0, help='List of gpu ids')
     parser.add_argument("--num_workers", type=int, default=0, help="Dataloader num_workers")
     parser.add_argument("--pin_memory", action='store_true', help="Dataloader pin_memory")
     parser.add_argument("--extension", type=str, default='wav', help="Choose extension for validation")
-    parser.add_argument("--use_tta", action='store_true', help="Flag adds test time augmentation during inference (polarity and channel inverse). While this triples the runtime, it reduces noise and slightly improves prediction quality.")
-    parser.add_argument("--metrics", nargs='+', type=str, default=["sdr"], choices=['sdr', 'l1_freq', 'si_sdr', 'neg_log_wmse', 'aura_stft', 'aura_mrstft', 'bleedless', 'fullness'], help='List of metrics to use.')
+    parser.add_argument("--use_tta", action='store_true',
+                        help="Flag adds test time augmentation during inference (polarity and channel inverse)."
+                        "While this triples the runtime, it reduces noise and slightly improves prediction quality.")
+    parser.add_argument("--metrics", nargs='+', type=str, default=["sdr"],
+                        choices=['sdr', 'l1_freq', 'si_sdr', 'neg_log_wmse', 'aura_stft', 'aura_mrstft', 'bleedless',
+                                 'fullness'], help='List of metrics to use.')
     parser.add_argument("--lora_checkpoint", type=str, default='', help="Initial checkpoint to LoRA weights")
 
-    if args is None:
+    if dict_args is None:
         args = parser.parse_args()
     else:
-        args = parser.parse_args(args)
+        args = argparse.Namespace(**dict_args)
 
+    return args
+
+
+def check_validation(dict_args):
+    args = parse_args(dict_args)
     torch.backends.cudnn.benchmark = True
     try:
         torch.multiprocessing.set_start_method('spawn')


### PR DESCRIPTION
1. Refactored argument collection in train.py, valid.py, inference.py, redact_config.py, trim.py, valid_to_inference.py, tests.py, and admin_test.py into a separate parse_args function. parse_args now supports passing a dict_args dictionary as an alternative to command-line arguments.
2. Added a new module admin_test.py:
   - MODEL_CONFIGS allows specifying config names and corresponding arguments.
   - The test_cache folder is automatically created with:
     - configs with reduced batch_size, num_epochs, num_steps, and gradient_accumulation_steps;
     - train and valid tracks with required stems (default: 2); - original for inference.
   - The test_cache folder is automatically deleted if everything works correctly.