### PR TITLE
Fix log_wmse +/- sign when used as metric

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -118,7 +118,7 @@ def L1Freq_metric(
     return ret
 
 
-def NegLogWMSE_metric(
+def LogWMSE_metric(
         reference: np.ndarray,
         estimate: np.ndarray,
         mixture: np.ndarray,
@@ -164,7 +164,7 @@ def NegLogWMSE_metric(
     mixture = torch.from_numpy(mixture).unsqueeze(0).to(device)
 
     res = log_wmse(mixture, reference, estimate)
-    return -float(res.cpu().numpy())
+    return float(res.cpu().numpy())
 
 
 def AuraSTFT_metric(
@@ -403,7 +403,7 @@ def get_metrics(
         result['l1_freq'] = L1Freq_metric(reference, estimate, device=device)
 
     if 'neg_log_wmse' in metrics:
-        result['neg_log_wmse'] = NegLogWMSE_metric(reference, estimate, mix, device)
+        result['neg_log_wmse'] = LogWMSE_metric(reference, estimate, mix, device)
 
     if 'aura_stft' in metrics:
         result['aura_stft'] = AuraSTFT_metric(reference, estimate, device)

--- a/train.py
+++ b/train.py
@@ -63,10 +63,10 @@ def parse_args(dict_args: Union[Dict, None]) -> argparse.Namespace:
     parser.add_argument("--wandb_key", type=str, default='', help='wandb API Key')
     parser.add_argument("--pre_valid", action='store_true', help='Run validation before training')
     parser.add_argument("--metrics", nargs='+', type=str, default=["sdr"],
-                        choices=['sdr', 'l1_freq', 'si_sdr', 'neg_log_wmse', 'aura_stft', 'aura_mrstft', 'bleedless',
+                        choices=['sdr', 'l1_freq', 'si_sdr', 'log_wmse', 'aura_stft', 'aura_mrstft', 'bleedless',
                                  'fullness'], help='List of metrics to use.')
     parser.add_argument("--metric_for_scheduler", default="sdr",
-                        choices=['sdr', 'l1_freq', 'si_sdr', 'neg_log_wmse', 'aura_stft', 'aura_mrstft', 'bleedless',
+                        choices=['sdr', 'l1_freq', 'si_sdr', 'log_wmse', 'aura_stft', 'aura_mrstft', 'bleedless',
                                  'fullness'], help='Metric which will be used for scheduler.')
     parser.add_argument("--train_lora", action='store_true', help="Train with LoRA")
     parser.add_argument("--lora_checkpoint", type=str, default='', help="Initial checkpoint to LoRA weights")


### PR DESCRIPTION
As "return_as_loss=False" is used in log_wmse metric initialisation, there's no need to change sign of the returned value.