### PR TITLE
Change conformer repo to lucidrains repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Available models for training:
 * BandIt v2 [[Paper](https://arxiv.org/abs/2407.07275), [Repository](https://github.com/kwatcharasupat/bandit-v2)] Key: `bandit_v2`.
 * Apollo [[Paper](https://arxiv.org/html/2409.08514v1), [Repository](https://github.com/JusperLee/Apollo)] Key: `apollo`.
 * TS BSMamba2 [[Paper](https://arxiv.org/pdf/2409.06245), [Repository](https://github.com/baijinglin/TS-BSmamba2)] Key: `bs_mamba2`.
-* Conformer [[Paper](https://arxiv.org/abs/2005.08100), [Repository](https://github.com/dillfrescott/mvsep-beta)] Key: `conformer`.
+* Conformer [[Paper](https://arxiv.org/abs/2005.08100), [Repository](https://github.com/lucidrains/conformer)] Key: `conformer`.
 * SCNet Tran Key: `scnet_tran`.
 * SCNet Masked Key: `scnet_masked`.
 


### PR DESCRIPTION
You should probably link lucidrains official repo as the conformer repository as thats also what I use in my scripts and the original implementation.