### PR TITLE
inference: validate sndfile codec/subtype combination

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -108,7 +108,7 @@ def run_folder(model, args, config, device, verbose: bool = False):
                     estimates = denormalize_audio(estimates, norm_params)
 
             codec = 'flac' if getattr(args, 'flac_file', False) else 'wav'
-            subtype = 'PCM_16' if args.flac_file and args.pcm_type == 'PCM_16' else 'FLOAT'
+            subtype = args.pcm_type
 
             output_path = os.path.join(output_dir, f"{instr}.{codec}")
             sf.write(output_path, estimates.T, sr, subtype=subtype)


### PR DESCRIPTION
Fixes #188

libsndfile doesn't support all combinations of codecs/subtypes. If an invalid one is selected, `inference.py` errors out after inference is completed, without writing results. Also, the default subtype for flac files is FLOAT, which is unsupported for flac, making inference fail every time for --flac if --pcm_type is not also provided.

This PR validates the combination early, and ensures a valid one using `sf.default_subtype(codec)`. The default choice of FLAC from `inference.py` is now kept in `parse_args_inference()`.
