### PR TITLE
inference: add args.filename_template

### DIFF
--- a/utils/settings.py
+++ b/utils/settings.py
@@ -195,6 +195,8 @@ def parse_args_inference(dict_args: Union[Dict, None]) -> argparse.Namespace:
                         help="Flag adds test time augmentation during inference (polarity and channel inverse)."
                         "While this triples the runtime, it reduces noise and slightly improves prediction quality.")
     parser.add_argument("--lora_checkpoint", type=str, default='', help="Initial checkpoint to LoRA weights")
+    parser.add_argument("--filename_template", type=str, default='{file_name}/{instr}',
+                        help="Output filename template, without extension, using '/' for subdirectories. Default: '{file_name}/{instr}'")
 
     if dict_args is not None:
         args = parser.parse_args([])


### PR DESCRIPTION
small quality-of-life contribution I found useful in my workflow.

adds a new arg to inference.py to format output file names/dir structures:

```
python inference.py ... --filename_template '{file_name}/{model}/{instr}'
```

users can use forward slashes to define directory structures, it should work cross-platform.
by default, it uses the current format '{file_name}/{instr}'.
