### PR TITLE
Add --trim option to moises_to_musdb.py to trim stems to shortest length

### DIFF
--- a/scripts/moises_to_musdb.py
+++ b/scripts/moises_to_musdb.py
@@ -57,12 +57,14 @@ def files_to_categories(src_folder: str, categories: List[str]) -> Dict[str, Lis
 
 
 # Processes a folder containing audio tracks, copying and combining necessary files into the target structure
-def process_folder(src_folder: str, dest_folder: str, stems: List[str]) -> None:
+def process_folder(src_folder: str, dest_folder: str, stems: List[str], trim: bool = False) -> None:
     """
     Processes a folder containing audio tracks, copying and combining necessary files into the target structure.
     Parameters:
     - src_folder (str): Path to the source folder of MoisesDB.
     - dest_folder (str): Path to the target folder for MUSDB18.
+    - stems (List[str]): List of stem categories to process.
+    - trim (bool): If True, trim all stems to the length of the shortest one.
     """
 
     if not os.path.exists(dest_folder):
@@ -70,55 +72,117 @@ def process_folder(src_folder: str, dest_folder: str, stems: List[str]) -> None:
 
     categories = stems
 
-    # If the required stem does not exist in the source folder (src_folder),
-    # we add silence instead of the file with the same duration as the standard file.
-    problem_categories = []
-    duration = 0
-    all_files = files_to_categories(src_folder, categories)
+    if trim:
+        # First pass: load all stems and find the minimum length
+        stem_data = {}
+        sample_rate = None
+        min_length = float('inf')
+        all_files = files_to_categories(src_folder, categories)
 
-    # Using tqdm to display progress for categories
-    for category in tqdm(categories, desc=f"Processing categories in {os.path.basename(src_folder)}"):
-        files = all_files[category]
-        if files:
-            if len(files) > 1:
-                combined_data, sample_rate = combine_audio_files(files)
+        # Using tqdm to display progress for categories
+        for category in tqdm(categories, desc=f"Processing categories in {os.path.basename(src_folder)}"):
+            files = all_files[category]
+            if files:
+                if len(files) > 1:
+                    combined_data, sr = combine_audio_files(files)
+                else:
+                    combined_data, sr = sf.read(files[0])
+
+                stem_data[category] = combined_data
+                sample_rate = sr
+                min_length = min(min_length, len(combined_data))
+
+        # Process 'other' files
+        other_files = all_files['other']
+        if other_files:
+            other_combined_data, sr = combine_audio_files(other_files)
+            stem_data['other'] = other_combined_data
+            sample_rate = sr
+            min_length = min(min_length, len(other_combined_data))
+
+        # If no stems were found, set a default sample rate
+        if sample_rate is None:
+            sample_rate = 44100
+            min_length = 0
+
+        # Second pass: trim all stems to min_length and save
+        for category in categories:
+            if category in stem_data:
+                trimmed_data = stem_data[category][:min_length]
+                sf.write(os.path.join(dest_folder, f"{category}.wav"), trimmed_data, sample_rate)
             else:
-                combined_data, sample_rate = sf.read(files[0])
+                # Create silence with min_length
+                silence = np.zeros((min_length, 2), dtype=np.float32)
+                sf.write(os.path.join(dest_folder, f"{category}.wav"), silence, sample_rate)
 
-            sf.write(os.path.join(dest_folder, f"{category}.wav"), combined_data, sample_rate)
-            duration = max(duration, len(combined_data) / sample_rate)
+        # Save 'other' stem
+        if 'other' in stem_data:
+            trimmed_other = stem_data['other'][:min_length]
+            sf.write(os.path.join(dest_folder, "other.wav"), trimmed_other, sample_rate)
         else:
-            problem_categories.append(category)
+            silence = np.zeros((min_length, 2), dtype=np.float32)
+            sf.write(os.path.join(dest_folder, "other.wav"), silence, sample_rate)
 
-    other_files = all_files['other']
-    if other_files:
-        other_combined_data, sample_rate = combine_audio_files(other_files)
-        sf.write(os.path.join(dest_folder, "other.wav"), other_combined_data, sample_rate)
+        # Create mixture.wav from all files, then trim to min_length
+        all_files_list = [file for sublist in all_files.values() for file in sublist]
+        if all_files_list:
+            mixture_data, sample_rate = combine_audio_files(all_files_list)
+            mixture_data = mixture_data[:min_length]
+            sf.write(os.path.join(dest_folder, "mixture.wav"), mixture_data, sample_rate)
+        else:
+            # If no files at all, create silent mixture
+            silence = np.zeros((min_length, 2), dtype=np.float32)
+            sf.write(os.path.join(dest_folder, "mixture.wav"), silence, sample_rate)
     else:
-        problem_categories.append('other')
+        # Original behavior: If the required stem does not exist in the source folder (src_folder),
+        # we add silence instead of the file with the same duration as the standard file.
+        problem_categories = []
+        duration = 0
+        all_files = files_to_categories(src_folder, categories)
 
-    for category in problem_categories:
-        silence = np.zeros((int(duration * sample_rate), 2), dtype=np.float32)
-        sf.write(os.path.join(dest_folder, f"{category}.wav"), silence, sample_rate)
-    # mixture.wav
-    all_files_list = [file for sublist in all_files.values() for file in sublist]
-    mixture_data, sample_rate = combine_audio_files(all_files_list)
-    sf.write(os.path.join(dest_folder, "mixture.wav"), mixture_data, sample_rate)
+        # Using tqdm to display progress for categories
+        for category in tqdm(categories, desc=f"Processing categories in {os.path.basename(src_folder)}"):
+            files = all_files[category]
+            if files:
+                if len(files) > 1:
+                    combined_data, sample_rate = combine_audio_files(files)
+                else:
+                    combined_data, sample_rate = sf.read(files[0])
+
+                sf.write(os.path.join(dest_folder, f"{category}.wav"), combined_data, sample_rate)
+                duration = max(duration, len(combined_data) / sample_rate)
+            else:
+                problem_categories.append(category)
+
+        other_files = all_files['other']
+        if other_files:
+            other_combined_data, sample_rate = combine_audio_files(other_files)
+            sf.write(os.path.join(dest_folder, "other.wav"), other_combined_data, sample_rate)
+        else:
+            problem_categories.append('other')
+
+        for category in problem_categories:
+            silence = np.zeros((int(duration * sample_rate), 2), dtype=np.float32)
+            sf.write(os.path.join(dest_folder, f"{category}.wav"), silence, sample_rate)
+        # mixture.wav
+        all_files_list = [file for sublist in all_files.values() for file in sublist]
+        mixture_data, sample_rate = combine_audio_files(all_files_list)
+        sf.write(os.path.join(dest_folder, "mixture.wav"), mixture_data, sample_rate)
 
 
 # Wrapper function for 'process_folder' that unpacks the arguments
-def process_folder_wrapper(args: Tuple[str, str, List[str]]) -> None:
+def process_folder_wrapper(args: Tuple[str, str, List[str], bool]) -> None:
     """
     A wrapper function for 'process_folder' that unpacks the arguments.
     Parameters:
-    - args (Tuple[str, str]): A Tuple containing the source folder and destination folder paths.
+    - args (Tuple[str, str, List[str], bool]): A Tuple containing the source folder, destination folder paths, stems, and trim flag.
     """
-    src_folder, dest_folder, stems = args
-    return process_folder(src_folder, dest_folder, stems)
+    src_folder, dest_folder, stems, trim = args
+    return process_folder(src_folder, dest_folder, stems, trim)
 
 
 # Converts MoisesDB dataset to MUSDB18 format for a specified number of folders
-def convert_dataset(src_root: str, dest_root: str, stems: List[str], max_folders: int = 240, num_workers: int = 4) -> None:
+def convert_dataset(src_root: str, dest_root: str, stems: List[str], max_folders: int = 240, num_workers: int = 4, trim: bool = False) -> None:
     """
     Converts MoisesDB dataset to MUSDB18 format for a specified number of folders.
     Parameters:
@@ -126,6 +190,7 @@ def convert_dataset(src_root: str, dest_root: str, stems: List[str], max_folders
     - dest_root (str): Root directory where the new dataset will be saved.
     - max_folders (int): Maximum number of folders to process.
     - num_workers (int): Number of parallel workers for processing.
+    - trim (bool): If True, trim all stems to the length of the shortest one.
     """
     folders_to_process = []
     for folder in os.listdir(src_root):
@@ -136,7 +201,7 @@ def convert_dataset(src_root: str, dest_root: str, stems: List[str], max_folders
         dest_folder = os.path.join(dest_root, folder)
 
         if os.path.isdir(src_folder):
-            folders_to_process.append((src_folder, dest_folder, stems))
+            folders_to_process.append((src_folder, dest_folder, stems, trim))
         else:
             print(f"Skip {src_folder} — not dir")
 
@@ -219,6 +284,7 @@ def parse_args(dict_args: Union[Dict, None]) -> argparse.Namespace:
                         choices=['drums', 'guitar', 'vocals', 'bass', 'other_keys', 'piano', 'percussion',
                                  'bowed_strings', 'wind', 'other_plucked'], help='List of stems to use.')
     parser.add_argument('--mixture_name', type=str, default='mixture.wav', help="Name of mixture tracks")
+    parser.add_argument('--trim', action='store_true', help="Trim all stems to the length of the shortest one")
 
     if dict_args is not None:
         args = parser.parse_args([])
@@ -241,11 +307,13 @@ def main(args: Optional[argparse.Namespace] = None) -> None:
     num_workers = args.num_workers
     stems = args.stems
     max_folders = args.max_folders
+    trim = args.trim
 
     print(f'num_workers: {num_workers}, '
-          f'categories: {stems + ["other"]}')
+          f'categories: {stems + ["other"]}, '
+          f'trim: {trim}')
 
-    convert_dataset(source_directory, destination_directory, stems, max_folders=max_folders, num_workers=num_workers)
+    convert_dataset(source_directory, destination_directory, stems, max_folders=max_folders, num_workers=num_workers, trim=trim)
 
     print(f'All {max_folders} files have been processed, time: {time.time() - start:.2f} sec')
 


### PR DESCRIPTION
MoisesDB has inconsistent stem lengths for certain tracks, which can be problematic if one wants to use a tools like [museval](https://github.com/sigsep/sigsep-mus-eval) on inference results for testing.

The new ```--trim``` option allows the user to automatically trim all the combined stems (mixture, vocals, other, drums, bass) to the length of the shortest stem for each track.

running without ```--trim``` keeps original padding behavior.

The script now behaves as such:

Without ```--trim```
```
python scripts/moises_to_musdb.py\
   --src_dir /home/teraflops/Downloads/moisesdb/moisesdb_v0.1\
   --dest_dir /home/teraflops/Downloads/test_without_trim\
   --max_folders 10\
   --num_workers 4
num_workers: 4, categories: ['bass', 'drums', 'vocals', 'other'], trim: False
Processing categories in 8ba20549-c038-47c0-a808-e38741135911: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  6.62it/s]
Processing categories in 4b9f86f4-23e4-458b-839e-8a63b584bea3: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  5.96it/s]
Processing categories in 1a32e987-cae8-458f-9c26-d9a6abf5348d: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  4.41it/s]
Processing categories in 9653a690-c28c-4e8f-962e-ff7ed18b8ee9: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  3.28it/s]
Processing categories in 793b98a0-c776-4943-87eb-b7e07e50f531: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  6.08it/s]
Processing categories in 25789239-1075-43b9-bfc9-51dff4a29590: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  6.17it/s]
Processing categories in f97e0ccd-e2a1-4da9-b8b8-c58e11adc4d9: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  3.29it/s]
Processing categories in 9ce23a79-20eb-431a-80d2-eda3260ef503: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  9.69it/s]
Processing categories in 9ac2612b-e25f-4d27-8d43-b957e7e5a74b: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  4.95it/s]
Processing categories in 169628c5-266d-4e11-993b-440fa5fa2167: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  3.99it/s]
All 10 files have been processed, time: 4.23 sec
The end!

ls -l -B /home/teraflops/Downloads/test_without_trim/4b9f86f4-23e4-458b-839e-8a63b584bea3
.rw-r--r-- 34 927 244 teraflops  4 lis 00:01 bass.wav
.rw-r--r-- 34 927 244 teraflops  4 lis 00:01 drums.wav
.rw-r--r-- 35 127 340 teraflops  4 lis 00:01 mixture.wav
.rw-r--r-- 35 127 340 teraflops  4 lis 00:01 other.wav
.rw-r--r-- 34 927 244 teraflops  4 lis 00:01 vocals.wav
```

With ```--trim```
```
python scripts/moises_to_musdb.py\
   --src_dir /home/teraflops/Downloads/moisesdb/moisesdb_v0.1\
   --dest_dir /home/teraflops/Downloads/test_with_trim\
   --max_folders 10\
   --num_workers 4\
   --trim
num_workers: 4, categories: ['bass', 'drums', 'vocals', 'other'], trim: True
Processing categories in 8ba20549-c038-47c0-a808-e38741135911: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 10.79it/s]
Processing categories in 4b9f86f4-23e4-458b-839e-8a63b584bea3: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  9.78it/s]
Processing categories in 1a32e987-cae8-458f-9c26-d9a6abf5348d: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  6.90it/s]
Processing categories in 9653a690-c28c-4e8f-962e-ff7ed18b8ee9: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  4.77it/s]
Processing categories in 793b98a0-c776-4943-87eb-b7e07e50f531: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 10.48it/s]
Processing categories in 25789239-1075-43b9-bfc9-51dff4a29590: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  9.95it/s]
Processing categories in f97e0ccd-e2a1-4da9-b8b8-c58e11adc4d9: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  4.86it/s]
Processing categories in 169628c5-266d-4e11-993b-440fa5fa2167: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  7.25it/s]
Processing categories in 9ac2612b-e25f-4d27-8d43-b957e7e5a74b: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  7.90it/s]
Processing categories in 9ce23a79-20eb-431a-80d2-eda3260ef503: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 16.02it/s]
All 10 files have been processed, time: 4.40 sec
The end!

ls -l -B /home/teraflops/Downloads/test_with_trim/4b9f86f4-23e4-458b-839e-8a63b584bea3
.rw-r--r-- 34 927 244 teraflops  4 lis 00:01 bass.wav
.rw-r--r-- 34 927 244 teraflops  4 lis 00:01 drums.wav
.rw-r--r-- 34 927 244 teraflops  4 lis 00:01 mixture.wav
.rw-r--r-- 34 927 244 teraflops  4 lis 00:01 other.wav
.rw-r--r-- 34 927 244 teraflops  4 lis 00:01 vocals.wav
```

The resulting files are fully playable.