### PR TITLE
fix for reshaping issue with mdx23c leading to model collapse in some situations

### DIFF
--- a/models/mdx23c_tfc_tdf_v3.py
+++ b/models/mdx23c_tfc_tdf_v3.py
@@ -232,9 +232,8 @@ class TFC_TDF_net(nn.Module):
 
         x = self.cws2cac(x)
 
-        if self.num_target_instruments > 1:
-            b, c, f, t = x.shape
-            x = x.reshape(b, self.num_target_instruments, -1, f, t)
+        b, c, f, t = x.shape
+        x = x.reshape(b, self.num_target_instruments, -1, f, t)
 
         x = self.stft.inverse(x)
 


### PR DESCRIPTION
fix for https://github.com/ZFTurbo/Music-Source-Separation-Training/issues/209

(it's the reshaping issue that I have already reported on discord)