### PR TITLE
Adding BigShifts trick to inference

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -18,7 +18,7 @@ sys.path.append(current_dir)
 
 from utils.audio_utils import normalize_audio, denormalize_audio, draw_spectrogram
 from utils.settings import get_model_from_config, parse_args_inference
-from utils.model_utils import demix
+from utils.model_utils import bigshifts_wrapper
 from utils.model_utils import prefer_target_instrument, apply_tta, load_start_checkpoint
 
 import warnings
@@ -106,13 +106,14 @@ def run_folder(
                 mix, norm_params = normalize_audio(mix)
 
         # Perform source separation
-        waveforms_orig = demix(
+        waveforms_orig = bigshifts_wrapper(
             config,
             model,
             mix,
             device,
             model_type=args.model_type,
-            pbar=detailed_pbar
+            pbar=detailed_pbar,
+            bigshifts=args.bigshifts
         )
 
         # Apply test-time augmentation if enabled
@@ -123,7 +124,8 @@ def run_folder(
                 mix,
                 waveforms_orig,
                 device,
-                args.model_type
+                args.model_type,
+                bigshifts=args.bigshifts
             )
 
         # Extract instrumental track if requested

--- a/utils/model_utils.py
+++ b/utils/model_utils.py
@@ -15,6 +15,58 @@ from typing import Dict, List, Tuple, Any, Union, Optional
 import loralib as lora
 import torch.distributed as dist
 
+def bigshifts_wrapper(
+    config: ConfigDict,
+    model: torch.nn.Module,
+    mix: torch.Tensor,
+    device: torch.device,
+    model_type: str,
+    pbar: bool = False,
+    bigshifts: int = 1
+) -> Union[Dict[str, np.ndarray], np.ndarray]:
+    """BigShifts wrapper for inference-time demixing."""
+
+    should_print = not dist.is_initialized() or dist.get_rank() == 0
+
+    if bigshifts <= 0:
+        bigshifts = 1
+
+    if isinstance(mix, torch.Tensor):
+        mix = mix.detach().cpu().numpy()
+
+    shift_in_samples = mix.shape[1] // bigshifts
+    shifts = [x * shift_in_samples for x in range(bigshifts)]
+    results = []
+
+    if pbar and should_print:
+        shifts_iterator = tqdm(shifts, desc="BigShifts passes...", leave=False)
+    else:
+        shifts_iterator = shifts
+
+    for shift in shifts_iterator:
+        shifted_mix = np.concatenate((mix[:, -shift:], mix[:, :-shift]), axis=-1)
+        sources = demix(config, model, shifted_mix, device, model_type, pbar)
+
+        if isinstance(sources, dict):
+            unshifted = {
+                k: np.concatenate((v[..., shift:], v[..., :shift]), axis=-1)
+                for k, v in sources.items()
+            }
+            results.append(unshifted)
+        elif isinstance(sources, np.ndarray):
+            unshifted = np.concatenate((sources[..., shift:], sources[..., :shift]), axis=-1)
+            results.append(unshifted)
+        else:
+            raise ValueError("Unsupported return type from demix")
+
+    if isinstance(results[0], dict):
+        avg_result = {}
+        for k in results[0]:
+            avg_result[k] = np.mean([r[k] for r in results], axis=0)
+        return avg_result
+    return np.mean(results, axis=0)
+
+
 def demix(
     config: ConfigDict,
     model: torch.nn.Module,
@@ -335,7 +387,8 @@ def apply_tta(
     mix: torch.Tensor,
     waveforms_orig: Union[dict[str, np.ndarray], np.ndarray],
     device: torch.device,
-    model_type: str
+    model_type: str,
+    bigshifts: int = 1
 ) -> Union[dict[str, np.ndarray], np.ndarray]:
     """
     Enhance source separation results using Test-Time Augmentation (TTA).
@@ -362,7 +415,14 @@ def apply_tta(
 
     # Process each augmented mixture
     for i, augmented_mix in enumerate(track_proc_list):
-        waveforms = demix(config, model, augmented_mix, device, model_type=model_type)
+        waveforms = bigshifts_wrapper(
+            config,
+            model,
+            augmented_mix,
+            device,
+            model_type=model_type,
+            bigshifts=bigshifts
+        )
         for el in waveforms:
             if i == 0:
                 waveforms_orig[el] += waveforms[el][::-1].copy()

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -218,6 +218,8 @@ def parse_args_inference(dict_args: Union[Dict, None]) -> argparse.Namespace:
     parser.add_argument("--use_tta", action='store_true',
                         help="Flag adds test time augmentation during inference (polarity and channel inverse)."
                         "While this triples the runtime, it reduces noise and slightly improves prediction quality.")
+    parser.add_argument("--bigshifts", type=int, default=1,
+                        help="Number of circular time shifts to average during demix. Values <= 0 are treated as 1.")
     parser.add_argument("--lora_checkpoint_peft", type=str, default='', help="Initial checkpoint to LoRA weights")
     parser.add_argument("--filename_template", type=str, default='{file_name}/{instr}',
                         help="Output filename template, without extension, using '/' for subdirectories. Default: '{file_name}/{instr}'")


### PR DESCRIPTION
More efficient than high overlap value to improve a bit the separation, by doing a bunch of passes on the input audio (with some segments shifted in time for each passes, then restored, all passes are finally averaged).

Can be set with `--bigshifts 3` CLI argument