### PR TITLE
Added progress bar to additional TTA passes.

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -125,8 +125,8 @@ def run_folder(
                 waveforms_orig,
                 device,
                 args.model_type,
-                pbar=detailed_pbar,
-                bigshifts=args.bigshifts
+                bigshifts=args.bigshifts,
+                pbar=detailed_pbar
             )
 
         # Extract instrumental track if requested

--- a/inference.py
+++ b/inference.py
@@ -125,6 +125,7 @@ def run_folder(
                 waveforms_orig,
                 device,
                 args.model_type,
+                pbar=detailed_pbar,
                 bigshifts=args.bigshifts
             )
 

--- a/utils/model_utils.py
+++ b/utils/model_utils.py
@@ -388,8 +388,8 @@ def apply_tta(
     waveforms_orig: Union[dict[str, np.ndarray], np.ndarray],
     device: torch.device,
     model_type: str,
-    pbar: bool = False,
-    bigshifts: int = 1
+    bigshifts: int = 1,
+    pbar: bool = False
 ) -> Union[dict[str, np.ndarray], np.ndarray]:
     """
     Enhance source separation results using Test-Time Augmentation (TTA).
@@ -422,8 +422,8 @@ def apply_tta(
             augmented_mix,
             device,
             model_type=model_type,
-            pbar=pbar,
-            bigshifts=bigshifts
+            bigshifts=bigshifts,
+            pbar=pbar
         )
         for el in waveforms:
             if i == 0:

--- a/utils/model_utils.py
+++ b/utils/model_utils.py
@@ -388,6 +388,7 @@ def apply_tta(
     waveforms_orig: Union[dict[str, np.ndarray], np.ndarray],
     device: torch.device,
     model_type: str,
+    pbar: bool = False,
     bigshifts: int = 1
 ) -> Union[dict[str, np.ndarray], np.ndarray]:
     """
@@ -421,6 +422,7 @@ def apply_tta(
             augmented_mix,
             device,
             model_type=model_type,
+            pbar=pbar,
             bigshifts=bigshifts
         )
         for el in waveforms:


### PR DESCRIPTION
Progress bar was not visible during the 2nd and 3rd pass when --use_tta parameter was used with inference.py.
Now it is visible during all passed, even when combined with --bigshifts parameter.

The change was done with the help of AI (Gemini 3.1 Pro in Github Copilot) and manually tested.