### PR TITLE
Fix parameter signature mismatch in save_last_weights call

### DIFF
--- a/train.py
+++ b/train.py
@@ -448,7 +448,7 @@ def train_model(args: Union[argparse.Namespace, None], rank=None, world_size=Non
         model_to_valid = ema_model if ema_model is not None else model
 
         if should_print:
-            save_last_weights(args, model, device_ids, optimizer, epoch, all_time_all_metrics, best_metric, scheduler)
+            save_last_weights(args, model, device_ids, optimizer, epoch, all_time_all_metrics, all_losses, best_metric, scheduler)
         if ddp:
             metrics_avg, all_metrics = valid_multi_gpu(model, args, config, args.device_ids, verbose=False)
             if rank == 0:


### PR DESCRIPTION
This is very important. A forgotten argument was causing incorrectly written model file.

I would recommend setting up a Python linter to avoid errors like this in future.