### PR TITLE
Optimize zero-dc filtering by avoiding extra GPU tensor allocations

### DIFF
--- a/models/bs_roformer/bs_conformer.py
+++ b/models/bs_roformer/bs_conformer.py
@@ -680,7 +680,7 @@ class BSConformer(Module):
         stft_repr = rearrange(stft_repr, 'b n (f s) t -> (b n s) f t', s = self.audio_channels)
 
         if self.zero_dc:
-            stft_repr = stft_repr.index_fill(1, tensor(0, device = device), 0.)
+            stft_repr[:, 0] = 0.
 
         try:
             recon_audio = torch.istft(stft_repr, **self.stft_kwargs, window = stft_window, return_complex = False, length = raw_audio.shape[-1])

--- a/models/bs_roformer/bs_roformer.py
+++ b/models/bs_roformer/bs_roformer.py
@@ -646,7 +646,7 @@ class BSRoformer(Module):
 
         if self.zero_dc:
             # whether to dc filter
-            stft_repr = stft_repr.index_fill(1, tensor(0, device = device), 0.)
+            stft_repr[:, 0] = 0.
 
         try:
             recon_audio = torch.istft(stft_repr, **self.stft_kwargs, window=stft_window, return_complex=False, length=raw_audio.shape[-1])

--- a/models/bs_roformer/mel_band_conformer.py
+++ b/models/bs_roformer/mel_band_conformer.py
@@ -681,7 +681,7 @@ class MelBandConformer(Module):
         stft_repr = rearrange(stft_repr, 'b n (f s) t -> (b n s) f t', s=self.audio_channels)
 
         if self.zero_dc:
-            stft_repr = stft_repr.index_fill(1, torch.tensor(0, device=device), 0.)
+            stft_repr[:, 0] = 0.
 
         recon_audio = torch.istft(
             stft_repr,

--- a/models/bs_roformer/mel_band_roformer.py
+++ b/models/bs_roformer/mel_band_roformer.py
@@ -688,7 +688,7 @@ class MelBandRoformer(Module):
 
         if self.zero_dc:
             # whether to dc filter
-            stft_repr = stft_repr.index_fill(1, tensor(0, device = device), 0.)
+            stft_repr[:, 0] = 0.
 
         recon_audio = torch.istft(stft_repr, **self.stft_kwargs, window=stft_window, return_complex=False,
                                   length=istft_length)


### PR DESCRIPTION
This is not a bug fix, but a performance optimization. The problem is, `index_fill()` creates a whole new tensor which may occupy many GB of RAM. It's best to do zero fill inplace.