### PR TITLE
add a multiresolution wrapper to bleedless/fullness metrics

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -385,6 +385,67 @@ def bleed_full(
     return bleedless.cpu().numpy(), fullness.cpu().numpy()
 
 
+def bleed_full_multiresolution(
+        reference: np.ndarray,
+        estimate: np.ndarray,
+        sr: int = 44100,
+        n_fft: List[int] = [1024, 2048, 4096, 8192],
+        device: str = 'cpu',
+) -> Tuple[float, float]:
+    """
+    Multiresolution wrapper for the bleed/fullness metrics.
+
+    Computes ``bleed_full`` at several FFT resolutions and averages the results.
+    For each FFT size, the hop length and number of mel bins are derived as
+    ``hop_length = n_fft // 4`` and ``n_mels = n_fft // 8`` so only the FFT size
+    needs to be provided.
+
+    Parameters:
+    ----------
+    reference : np.ndarray
+        The reference audio signal, shape (channels, time).
+
+    estimate : np.ndarray
+        The estimated audio signal, shape (channels, time).
+
+    sr : int, optional
+        The sample rate of the audio signals. Default is 44100 Hz.
+
+    n_fft : List[int], optional
+        The list of FFT sizes used for the multi-resolution computation.
+        Default is [1024, 2048, 4096, 8192].
+
+    device : str, optional
+        The device for computation, either 'cpu' or 'cuda'. Default is 'cpu'.
+
+    Returns:
+    -------
+    tuple
+        A tuple containing two values averaged over the requested resolutions:
+        - `bleedless` (float): averaged bleedless score (higher is better).
+        - `fullness` (float): averaged fullness score (higher is better).
+    """
+    bleedless_vals = []
+    fullness_vals = []
+    for fft_size in n_fft:
+        b, f = bleed_full(
+            reference,
+            estimate,
+            sr=sr,
+            n_fft=int(fft_size),
+            hop_length=int(fft_size) // 4,
+            n_mels=int(fft_size) // 8,
+            device=device,
+        )
+        bleedless_vals.append(float(b))
+        fullness_vals.append(float(f))
+
+    bleedless = float(np.mean(bleedless_vals))
+    fullness = float(np.mean(fullness_vals))
+
+    return bleedless, fullness
+
+
 def get_metrics(
         metrics: List[str],
         reference: np.ndarray,
@@ -458,5 +519,12 @@ def get_metrics(
             result['bleedless'] = float(bleedless)
         if 'fullness' in metrics:
             result['fullness'] = float(fullness)
+
+    if 'bleedless_mr' in metrics or 'fullness_mr' in metrics:
+        bleedless_mr, fullness_mr = bleed_full_multiresolution(reference, estimate, device=device)
+        if 'bleedless_mr' in metrics:
+            result['bleedless_mr'] = float(bleedless_mr)
+        if 'fullness_mr' in metrics:
+            result['fullness_mr'] = float(fullness_mr)
 
     return result

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -84,10 +84,12 @@ def parse_args_train(dict_args: Union[argparse.Namespace, Dict, None]) -> argpar
     parser.add_argument("--pre_valid", action='store_true', help='Run validation before training')
     parser.add_argument("--metrics", nargs='+', type=str, default=["sdr"],
                         choices=['k_sdr', 'sdr', 'l1_freq', 'si_sdr', 'log_wmse', 'aura_stft', 'aura_mrstft', 'bleedless',
-                                 'fullness', 'l1_snr'], help='List of metrics to use.')
+                                 'fullness', 'l1_snr', 'bleedless_mr', 'fullness_mr'],
+                        help='List of metrics to use.')
     parser.add_argument("--metric_for_scheduler", default="sdr",
                         choices=['k_sdr','sdr', 'l1_freq', 'si_sdr', 'log_wmse', 'aura_stft', 'aura_mrstft', 'bleedless',
-                                 'fullness', 'l1_snr'], help='Metric which will be used for scheduler.')
+                                 'fullness', 'l1_snr', 'bleedless_mr', 'fullness_mr'],
+                        help='Metric which will be used for scheduler.')
     parser.add_argument("--train_lora_peft", action='store_true', help="Training with LoRA from peft")
     parser.add_argument("--train_lora_loralib", action='store_true', help="Training with LoRA from loralib")
     parser.add_argument("--lora_checkpoint_peft", type=str, default='', help="Initial checkpoint to LoRA weights")
@@ -166,7 +168,8 @@ def parse_args_valid(dict_args: Union[Dict, None]) -> argparse.Namespace:
                              "While this triples the runtime, it reduces noise and slightly improves prediction quality.")
     parser.add_argument("--metrics", nargs='+', type=str, default=["sdr"],
                         choices=['k_sdr', 'sdr', 'l1_freq', 'si_sdr', 'neg_log_wmse', 'aura_stft', 'aura_mrstft', 'bleedless',
-                                 'fullness', 'l1_snr'], help='List of metrics to use.')
+                                 'fullness', 'l1_snr', 'bleedless_mr', 'fullness_mr'],
+                        help='List of metrics to use.')
     parser.add_argument("--lora_checkpoint_peft", type=str, default='', help="Initial checkpoint to LoRA weights")
     parser.add_argument("--lora_checkpoint_loralib", type=str, default='', help="Initial checkpoint to LoRA weights")
 


### PR DESCRIPTION
`bleedless_mr` and `fullness_mr` can now be used for multiresolution bleedless/fullness metrics.
Single resolution version is still available for compatibility

Default `n_fft` resolutions are [1024, 2048, 4096, 8192], with `hop_length=n_fft//4` and `n_mels=n_fft//8`